### PR TITLE
refactor(#31): extract duplicate MD5 hashing logic to helper function

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -11,4 +11,6 @@ fileignoreconfig:
   checksum: 58689981ad53f2d8e3ec7050e03fa1a8d7eed51365f3d2147ebca9d5f0ae2829
 - filename: lib/ocdc-poll
   checksum: 3d7076a52d1698fd04fb2e5ca44889710316e9febdefb05dba16ca34f244a989
+- filename: test/test_paths.bash
+  checksum: c99eca6d022f1c0ad836c57ee974d3110b32b19ffe9578ef4b30f5d5b51300dd
 version: "1.0"

--- a/lib/ocdc-down
+++ b/lib/ocdc-down
@@ -83,7 +83,7 @@ stop_container() {
   log "Stopping container for $repo (port $port)..."
   
   # Generate workspace ID for override file
-  local ws_id=$(echo "$ws" | md5 -q 2>/dev/null || echo "$ws" | md5sum | cut -d' ' -f1)
+  local ws_id=$(ocdc_path_id "$ws")
   local override_file="${OVERRIDES_DIR}/${ws_id}.json"
   
   # Try to stop via devcontainer CLI
@@ -130,7 +130,7 @@ prune_stale() {
       jq --arg ws "$ws" 'del(.[$ws])' "$PORTS_FILE" > "$tmp" && mv "$tmp" "$PORTS_FILE"
       
       # Clean up override file
-      local ws_id=$(echo "$ws" | md5 -q 2>/dev/null || echo "$ws" | md5sum | cut -d' ' -f1)
+      local ws_id=$(ocdc_path_id "$ws")
       rm -f "${OVERRIDES_DIR}/${ws_id}.json"
       
       ((pruned++)) || true

--- a/lib/ocdc-exec
+++ b/lib/ocdc-exec
@@ -74,7 +74,7 @@ if ! jq -e --arg ws "$WORKSPACE" '.[$ws]' "$PORTS_FILE" >/dev/null 2>&1; then
 fi
 
 # Get workspace ID for override file
-WORKSPACE_ID=$(echo "$WORKSPACE" | md5 -q 2>/dev/null || echo "$WORKSPACE" | md5sum | cut -d' ' -f1)
+WORKSPACE_ID=$(ocdc_path_id "$WORKSPACE")
 OVERRIDE_FILE="${OVERRIDES_DIR}/${WORKSPACE_ID}.json"
 
 # Build exec args

--- a/lib/ocdc-paths.bash
+++ b/lib/ocdc-paths.bash
@@ -28,6 +28,14 @@ OCDC_POLLS_DIR="${OCDC_POLLS_DIR:-${OCDC_CONFIG_DIR}/polls}"
 _LEGACY_CONFIG_DIR="${HOME}/.config/devcontainer-multi"
 _LEGACY_CACHE_DIR="${HOME}/.cache/devcontainer-multi"
 
+# Generate a stable ID from a path using MD5 hash
+# Used for workspace identifiers, not security (short, deterministic IDs)
+# Works on both macOS (md5) and Linux (md5sum)
+ocdc_path_id() {
+  local path="$1"
+  echo "$path" | md5 -q 2>/dev/null || echo "$path" | md5sum | cut -d' ' -f1
+}
+
 # Ensure all required directories exist
 ocdc_ensure_dirs() {
   mkdir -p "$OCDC_CONFIG_DIR"

--- a/lib/ocdc-up
+++ b/lib/ocdc-up
@@ -245,7 +245,7 @@ if [[ ! -f "$WORKSPACE/.devcontainer/devcontainer.json" ]] && [[ ! -f "$WORKSPAC
 fi
 
 # Generate workspace identifier (hash of absolute path)
-WORKSPACE_ID=$(echo "$WORKSPACE" | md5 -q 2>/dev/null || echo "$WORKSPACE" | md5sum | cut -d' ' -f1)
+WORKSPACE_ID=$(ocdc_path_id "$WORKSPACE")
 
 # Find available port
 find_available_port() {


### PR DESCRIPTION
## Summary
- Extracted duplicate MD5 hashing logic to `ocdc_path_id()` helper in `ocdc-paths.bash`
- Replaced 4 inline instances across `ocdc-up`, `ocdc-exec`, and `ocdc-down`
- Added comprehensive test coverage for the new helper function