### PR TITLE
chore(#30): update legacy dcup/dcdown references to ocdc

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Setup script for devcontainer-multi development
+# Setup script for ocdc development
 #
 
 set -euo pipefail

--- a/lib/ocdc-down
+++ b/lib/ocdc-down
@@ -3,17 +3,17 @@
 # ocdc-down - Stop a devcontainer and release its port assignment
 #
 # Usage:
-#   dcdown              # Stop container for current directory
-#   dcdown <workspace>  # Stop container for specific workspace path
-#   dcdown --all        # Stop all tracked devcontainers
-#   dcdown --prune      # Remove stale port assignments (no running container)
+#   ocdc down              # Stop container for current directory
+#   ocdc down <workspace>  # Stop container for specific workspace path
+#   ocdc down --all        # Stop all tracked devcontainers
+#   ocdc down --prune      # Remove stale port assignments (no running container)
 #
 # Options:
 #   --remove-clone      Also remove the clone directory (if applicable)
 #
 # Related commands:
-#   dcup     - Start devcontainer
-#   dclist   - List active instances
+#   ocdc up     - Start devcontainer
+#   ocdc list   - List active instances
 
 set -euo pipefail
 

--- a/lib/ocdc-exec
+++ b/lib/ocdc-exec
@@ -3,18 +3,18 @@
 # ocdc-exec - Execute a command in a running devcontainer
 #
 # Usage:
-#   dcexec <command> [args...]   # Run command in current workspace's container
-#   dcexec --workspace <path> <command> [args...]
+#   ocdc exec <command> [args...]   # Run command in current workspace's container
+#   ocdc exec --workspace <path> <command> [args...]
 #
 # Examples:
-#   dcexec bash                  # Open shell in container
-#   dcexec bin/rails console    # Run rails console
-#   dcexec npm test             # Run tests
+#   ocdc exec bash                  # Open shell in container
+#   ocdc exec bin/rails console    # Run rails console
+#   ocdc exec npm test             # Run tests
 #
 # Related commands:
-#   dcup     - Start devcontainer
-#   dcdown   - Stop devcontainer
-#   dclist   - List active instances
+#   ocdc up     - Start devcontainer
+#   ocdc down   - Stop devcontainer
+#   ocdc list   - List active instances
 
 set -euo pipefail
 
@@ -54,7 +54,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ ${#CMD_ARGS[@]} -gt 0 ]] || error "No command specified. Usage: dcexec <command> [args...]"
+[[ ${#CMD_ARGS[@]} -gt 0 ]] || error "No command specified. Usage: ocdc exec <command> [args...]"
 
 # Determine workspace
 if [[ -z "$WORKSPACE" ]]; then
@@ -70,7 +70,7 @@ WORKSPACE=$(cd "$WORKSPACE" 2>/dev/null && pwd -P || echo "$WORKSPACE")
 
 # Check if workspace is tracked
 if ! jq -e --arg ws "$WORKSPACE" '.[$ws]' "$PORTS_FILE" >/dev/null 2>&1; then
-  error "No devcontainer tracked for: $WORKSPACE\nUse 'dcup' to start one."
+  error "No devcontainer tracked for: $WORKSPACE\nUse 'ocdc up' to start one."
 fi
 
 # Get workspace ID for override file

--- a/lib/ocdc-go
+++ b/lib/ocdc-go
@@ -3,22 +3,22 @@
 # ocdc-go - Navigate to an existing devcontainer clone
 #
 # Usage:
-#   dcgo                    # List available clones for current repo
-#   dcgo <branch>           # Go to specific branch clone
-#   dcgo --vscode <branch>  # Open in VS Code instead of printing cd
+#   ocdc go                    # List available clones for current repo
+#   ocdc go <branch>           # Go to specific branch clone
+#   ocdc go --vscode <branch>  # Open in VS Code instead of printing cd
 #
 # Examples:
-#   dcgo feature-x          # Print: cd ~/.cache/devcontainer-clones/myapp/feature-x
-#   dcgo --vscode feature-x # Opens VS Code in that directory
-#   eval $(dcgo feature-x)  # Actually cd to the directory
+#   ocdc go feature-x          # Print: cd ~/.cache/devcontainer-clones/myapp/feature-x
+#   ocdc go --vscode feature-x # Opens VS Code in that directory
+#   eval $(ocdc go feature-x)  # Actually cd to the directory
 #
 # In VS Code terminal, automatically opens VS Code window.
 # In other terminals, prints the cd command (pipe to eval to execute).
 #
 # Related commands:
-#   dcup     - Start devcontainer (creates clone if needed)
-#   dclist   - List active instances
-#   dcdown   - Stop container
+#   ocdc up     - Start devcontainer (creates clone if needed)
+#   ocdc list   - List active instances
+#   ocdc down   - Stop container
 
 set -euo pipefail
 
@@ -100,7 +100,7 @@ if [[ -z "$BRANCH" ]]; then
   
   clones=$(list_clones "$REPO")
   if [[ -z "$clones" ]]; then
-    log "No clones found. Create one with: dcup <branch>"
+    log "No clones found. Create one with: ocdc up <branch>"
     exit 0
   fi
   
@@ -111,7 +111,7 @@ if [[ -z "$BRANCH" ]]; then
   done
   
   echo ""
-  log "Usage: dcgo <branch>"
+  log "Usage: ocdc go <branch>"
   exit 0
 fi
 
@@ -131,7 +131,7 @@ else
 fi
 
 if [[ -z "${WORKSPACE:-}" ]] || [[ ! -d "$WORKSPACE" ]]; then
-  error "Clone not found for branch '$BRANCH'. Create it with: dcup $BRANCH"
+  error "Clone not found for branch '$BRANCH'. Create it with: ocdc up $BRANCH"
 fi
 
 # Navigate or open

--- a/lib/ocdc-list
+++ b/lib/ocdc-list
@@ -3,15 +3,15 @@
 # ocdc-list - List devcontainer instances and clones
 #
 # Usage:
-#   dclist           # List all tracked instances and orphaned clones
-#   dclist --json    # Output as JSON
-#   dclist --active  # Only show instances with running containers
+#   ocdc list           # List all tracked instances and orphaned clones
+#   ocdc list --json    # Output as JSON
+#   ocdc list --active  # Only show instances with running containers
 #
 # Related commands:
-#   dcup     - Start devcontainer
-#   dcdown   - Stop devcontainer
-#   dcgo     - Navigate to clone
-#   dcclean  - Clean up orphaned clones
+#   ocdc up      - Start devcontainer
+#   ocdc down    - Stop devcontainer
+#   ocdc go      - Navigate to clone
+#   ocdc clean   - Clean up orphaned clones
 
 set -euo pipefail
 
@@ -204,9 +204,9 @@ else
   echo "* = current directory"
   echo ""
   echo "Commands:"
-  echo "  dcgo <branch>       Navigate to clone"
-  echo "  dcexec <cmd>        Execute command in container"
-  echo "  dcdown              Stop current container"
-  echo "  dcclean             Clean up orphaned clones"
-  echo "  dctui               Interactive TUI"
+  echo "  ocdc go <branch>       Navigate to clone"
+  echo "  ocdc exec <cmd>        Execute command in container"
+  echo "  ocdc down              Stop current container"
+  echo "  ocdc clean             Clean up orphaned clones"
+  echo "  ocdc tui               Interactive TUI"
 fi

--- a/lib/ocdc-tui
+++ b/lib/ocdc-tui
@@ -3,7 +3,7 @@
 # ocdc-tui - Interactive TUI for managing devcontainer instances
 #
 # Usage:
-#   dctui              # Launch interactive TUI
+#   ocdc tui              # Launch interactive TUI
 #
 # Navigation:
 #   ↑/↓ or j/k         Move selection up/down
@@ -15,10 +15,10 @@
 #   q                  Quit
 #
 # Related commands:
-#   dcup     - Start devcontainer
-#   dcdown   - Stop devcontainer  
-#   dclist   - List instances (non-interactive)
-#   dcclean  - Clean up orphaned clones
+#   ocdc up     - Start devcontainer
+#   ocdc down   - Stop devcontainer  
+#   ocdc list   - List instances (non-interactive)
+#   ocdc clean  - Clean up orphaned clones
 
 set -euo pipefail
 
@@ -221,7 +221,7 @@ open_workspace() {
     tput cnorm
     echo "Starting container for ${REPOS[$idx]}/${BRANCHES[$idx]}..."
     echo ""
-    (cd "$workspace" && dcup --no-open) 2>&1 || true
+    (cd "$workspace" && ocdc up --no-open) 2>&1 || true
     load_instances
     tput civis
     # Fall through to open it
@@ -269,7 +269,7 @@ stop_instance() {
   else
     # Container - stop it and optionally remove clone
     echo -e "Stopping ${BOLD}${repo}/${branch}${RESET} (port ${PORTS[$idx]})..."
-    dcdown "$workspace" 2>&1 || true
+    ocdc down "$workspace" 2>&1 || true
     
     # If it's a clone, offer to remove it
     if [[ "$workspace" == "$CLONES_DIR"* ]]; then
@@ -379,9 +379,9 @@ main() {
             continue
           fi
           
-          dcup "$branch" --no-open || true
+          ocdc up "$branch" --no-open || true
         else
-          dcup --no-open || true
+          ocdc up --no-open || true
         fi
         echo ""
         echo "Press any key to continue..."
@@ -405,7 +405,7 @@ main() {
         clear
         tput cnorm
         if confirm "Stop ALL containers?"; then
-          dcdown --all || true
+          ocdc down --all || true
         fi
         echo ""
         echo "Press any key to continue..."

--- a/lib/ocdc-up
+++ b/lib/ocdc-up
@@ -9,14 +9,14 @@
 #   - Tracking port assignments to avoid conflicts
 #
 # Usage:
-#   dcup                    # Start devcontainer for current directory
-#   dcup <branch>           # Create clone for branch, start devcontainer
-#   dcup --remove-existing  # Rebuild container from scratch
-#   dcup --no-open          # Don't open VS Code (just start container)
+#   ocdc up                    # Start devcontainer for current directory
+#   ocdc up <branch>           # Create clone for branch, start devcontainer
+#   ocdc up --remove-existing  # Rebuild container from scratch
+#   ocdc up --no-open          # Don't open VS Code (just start container)
 #
 # Examples:
-#   cd ~/Projects/myapp && dcup              # Start on port 13000
-#   cd ~/Projects/myapp && dcup feature-x    # Clone on port 13001
+#   cd ~/Projects/myapp && ocdc up              # Start on port 13000
+#   cd ~/Projects/myapp && ocdc up feature-x    # Clone on port 13001
 #
 # The container's internal port (e.g., 3000) is mapped to the assigned host port.
 # Access your app at http://localhost:<assigned-port>
@@ -31,10 +31,10 @@
 #   Clones are fully self-contained and work reliably with devcontainers.
 #
 # Related commands:
-#   dcdown   - Stop container and release port
-#   dclist   - List active instances
-#   dcexec   - Execute command in container
-#   dcgo     - Navigate to an existing clone
+#   ocdc down   - Stop container and release port
+#   ocdc list   - List active instances
+#   ocdc exec   - Execute command in container
+#   ocdc go     - Navigate to an existing clone
 #
 # Configuration:
 #   ~/.config/ocdc/config.json
@@ -260,7 +260,7 @@ find_available_port() {
       fi
     fi
   done
-  error "No available ports in range $PORT_START-$PORT_END. Use 'dcdown' to stop unused instances or 'dclist' to see active ones."
+  error "No available ports in range $PORT_START-$PORT_END. Use 'ocdc down' to stop unused instances or 'ocdc list' to see active ones."
 }
 
 # Get or assign port for this workspace
@@ -375,15 +375,15 @@ if devcontainer up "${UP_ARGS[@]}"; then
     log "To navigate to the clone:"
     echo "  cd $WORKSPACE"
     echo ""
-    log "Or use: dcgo $BRANCH"
+    log "Or use: ocdc go $BRANCH"
   fi
   
   echo ""
   log "Useful commands:"
-  log "  dcexec <cmd>     - Execute command in container"
-  log "  dcdown           - Stop this container"
-  log "  dclist           - List all instances"
-  [[ -n "$BRANCH" ]] && log "  dcgo $BRANCH     - Navigate to this clone"
+  log "  ocdc exec <cmd>     - Execute command in container"
+  log "  ocdc down           - Stop this container"
+  log "  ocdc list           - List all instances"
+  [[ -n "$BRANCH" ]] && log "  ocdc go $BRANCH     - Navigate to this clone"
 else
   # Clean up port assignment on failure
   tmp=$(mktemp)

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test helper functions for devcontainer-multi tests
+# Test helper functions for ocdc tests
 #
 
 # Test counters

--- a/test/test_naming.bash
+++ b/test/test_naming.bash
@@ -118,6 +118,21 @@ test_helper_no_legacy_project_name() {
   return 0
 }
 
+test_devcontainer_setup_no_legacy_project_name() {
+  local file="$PROJECT_DIR/.devcontainer/setup.sh"
+  if [[ ! -f "$file" ]]; then
+    echo "File not found: $file"
+    return 1
+  fi
+  # Check for devcontainer-multi in comments
+  if grep -nE 'devcontainer-multi' "$file" 2>/dev/null; then
+    echo "  Found 'devcontainer-multi' in: $file"
+    grep -nE 'devcontainer-multi' "$file" | head -3 | sed 's/^/    /'
+    return 1
+  fi
+  return 0
+}
+
 # =============================================================================
 # Run Tests
 # =============================================================================
@@ -131,7 +146,8 @@ for test_func in \
   test_ocdc_list_no_legacy_commands \
   test_ocdc_go_no_legacy_commands \
   test_ocdc_tui_no_legacy_commands \
-  test_helper_no_legacy_project_name
+  test_helper_no_legacy_project_name \
+  test_devcontainer_setup_no_legacy_project_name
 do
   run_test "${test_func#test_}" "$test_func"
 done


### PR DESCRIPTION
## Summary
- Add naming consistency tests to verify no legacy command references remain
- Update all dcup/dcdown/dclist/dcexec/dcgo/dctui/dcclean references to ocdc subcommand format
- Update devcontainer-multi project name references to ocdc

Closes #30