### PR TITLE
fix(#28): add path traversal protection in copy_gitignored_files

### DIFF
--- a/lib/ocdc-up
+++ b/lib/ocdc-up
@@ -155,6 +155,9 @@ copy_gitignored_files() {
   while IFS= read -r rel_path; do
     [[ -z "$rel_path" ]] && continue
     
+    # Skip paths with parent directory references (defense in depth)
+    [[ "$rel_path" == *".."* ]] && continue
+    
     # Skip lock files (generated, cause conflicts)
     local filename="${rel_path##*/}"
     if [[ "$filename" =~ ^($skip_files)$ ]]; then


### PR DESCRIPTION
## Summary
- Add defense-in-depth protection against path traversal in `copy_gitignored_files`
- Skip any paths containing `..` before file operations
- Add test case verifying suspicious paths are blocked while legitimate files are copied

Closes #28