### PR TITLE
fix(#29): consistent symlink resolution across all scripts

### DIFF
--- a/lib/ocdc-down
+++ b/lib/ocdc-down
@@ -159,11 +159,11 @@ if [[ -z "$WORKSPACE" ]]; then
   if git rev-parse --git-dir >/dev/null 2>&1; then
     WORKSPACE=$(git rev-parse --show-toplevel)
   else
-    WORKSPACE=$(pwd -P)
+    WORKSPACE=$(pwd)
   fi
 fi
 
-# Resolve to absolute path
-WORKSPACE=$(cd "$WORKSPACE" 2>/dev/null && pwd -P || echo "$WORKSPACE")
+# Resolve to absolute path with symlinks resolved
+WORKSPACE=$(ocdc_resolve_path "$WORKSPACE")
 
 stop_container "$WORKSPACE"

--- a/lib/ocdc-exec
+++ b/lib/ocdc-exec
@@ -61,12 +61,12 @@ if [[ -z "$WORKSPACE" ]]; then
   if git rev-parse --git-dir >/dev/null 2>&1; then
     WORKSPACE=$(git rev-parse --show-toplevel)
   else
-    WORKSPACE=$(pwd -P)
+    WORKSPACE=$(pwd)
   fi
 fi
 
-# Resolve to absolute path (use -P to resolve symlinks on macOS)
-WORKSPACE=$(cd "$WORKSPACE" 2>/dev/null && pwd -P || echo "$WORKSPACE")
+# Resolve to absolute path with symlinks resolved
+WORKSPACE=$(ocdc_resolve_path "$WORKSPACE")
 
 # Check if workspace is tracked
 if ! jq -e --arg ws "$WORKSPACE" '.[$ws]' "$PORTS_FILE" >/dev/null 2>&1; then

--- a/lib/ocdc-list
+++ b/lib/ocdc-list
@@ -60,10 +60,10 @@ get_tracked_workspaces() {
   fi
 }
 
-# Get current workspace for highlighting
+# Get current workspace for highlighting (resolve symlinks for consistent comparison)
 CURRENT_WS=""
 if git rev-parse --git-dir >/dev/null 2>&1; then
-  CURRENT_WS=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)
+  CURRENT_WS=$(ocdc_resolve_path "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
 fi
 
 if [[ "$JSON_OUTPUT" == "true" ]]; then

--- a/lib/ocdc-paths.bash
+++ b/lib/ocdc-paths.bash
@@ -36,6 +36,15 @@ ocdc_path_id() {
   echo "$path" | md5 -q 2>/dev/null || echo "$path" | md5sum | cut -d' ' -f1
 }
 
+# Resolve a path to its canonical absolute form, resolving symlinks
+# Returns the original input if the path doesn't exist
+# Note: Only works for directories, not files
+# Usage: resolved=$(ocdc_resolve_path "/some/path")
+ocdc_resolve_path() {
+  local path="$1"
+  (cd "$path" 2>/dev/null && pwd -P) || echo "$path"
+}
+
 # Ensure all required directories exist
 ocdc_ensure_dirs() {
   mkdir -p "$OCDC_CONFIG_DIR"

--- a/lib/ocdc-up
+++ b/lib/ocdc-up
@@ -115,8 +115,8 @@ command -v devcontainer >/dev/null 2>&1 || error "devcontainer CLI not found. In
 # Check we're in a git repo
 git rev-parse --git-dir >/dev/null 2>&1 || error "Not in a git repository"
 
-# Get repo info
-REPO_ROOT=$(git rev-parse --show-toplevel)
+# Get repo info (resolve symlinks for consistent workspace paths)
+REPO_ROOT=$(ocdc_resolve_path "$(git rev-parse --show-toplevel)")
 REPO_NAME=$(basename "$REPO_ROOT")
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
 


### PR DESCRIPTION
## Summary
- Add `ocdc_resolve_path` helper function for consistent symlink resolution
- Update `ocdc-up`, `ocdc-down`, `ocdc-exec`, and `ocdc-list` to use the new helper
- Ensures workspace paths in `ports.json` are always stored as physical paths, preventing mismatches when directories are accessed via symlinks

Closes #29