### PR TITLE
fix: source NVM and preserve PATH in devcontainer setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,12 +7,20 @@ set -euo pipefail
 
 echo "Installing dependencies..."
 
+# Source NVM environment (installed by devcontainer node feature)
+# This is needed because postCreateCommand runs via /bin/sh -c which doesn't
+# load the interactive shell profile where NVM is typically sourced
+export NVM_DIR="/usr/local/share/nvm"
+# shellcheck source=/dev/null
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
 # Install jq
 sudo apt-get update
 sudo apt-get install -y jq
 
 # Install devcontainer CLI
-sudo npm install -g @devcontainers/cli
+# Preserve PATH since sudo resets it and doesn't include NVM's node directory
+sudo env "PATH=$PATH" npm install -g @devcontainers/cli
 
 # Add bin to PATH by symlinking
 echo "Symlinking scripts to /usr/local/bin..."


### PR DESCRIPTION
## Summary
- Source NVM environment explicitly in setup.sh since postCreateCommand runs via /bin/sh
- Preserve PATH when running npm with sudo since sudo resets the PATH
- Fixes poll-triggered devcontainer builds that were failing silently, preventing issues with ocdc:ready label from being picked up