### PR TITLE
fix(#27): fix port assignment race condition with file locking

### DIFF
--- a/lib/ocdc-down
+++ b/lib/ocdc-down
@@ -20,9 +20,11 @@ set -euo pipefail
 # Source paths library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/ocdc-paths.bash"
+source "${SCRIPT_DIR}/../lib/ocdc-file-lock.bash"
 
 CACHE_DIR="$OCDC_CACHE_DIR"
 PORTS_FILE="$OCDC_PORTS_FILE"
+PORTS_LOCK="${CACHE_DIR}/ports.lock"
 OVERRIDES_DIR="$OCDC_OVERRIDES_DIR"
 CLONES_DIR="$OCDC_CLONES_DIR"
 
@@ -99,9 +101,11 @@ stop_container() {
   # Clean up override file
   [[ -f "$override_file" ]] && rm -f "$override_file"
   
-  # Remove port assignment
+  # Remove port assignment (with lock to prevent race conditions)
+  lock_file "$PORTS_LOCK"
   local tmp=$(mktemp)
   jq --arg ws "$ws" 'del(.[$ws])' "$PORTS_FILE" > "$tmp" && mv "$tmp" "$PORTS_FILE"
+  unlock_file "$PORTS_LOCK"
   
   log "Stopped and released port $port"
   
@@ -126,8 +130,12 @@ prune_stale() {
     # Check if anything is listening on that port
     if ! lsof -i ":$port" >/dev/null 2>&1; then
       log "Removing stale assignment: $ws (port $port)"
+      
+      # Remove port assignment (with lock to prevent race conditions)
+      lock_file "$PORTS_LOCK"
       local tmp=$(mktemp)
       jq --arg ws "$ws" 'del(.[$ws])' "$PORTS_FILE" > "$tmp" && mv "$tmp" "$PORTS_FILE"
+      unlock_file "$PORTS_LOCK"
       
       # Clean up override file
       local ws_id=$(ocdc_path_id "$ws")

--- a/lib/ocdc-file-lock.bash
+++ b/lib/ocdc-file-lock.bash
@@ -7,10 +7,29 @@
 #
 
 # Acquire a lock using mkdir (atomic operation)
-# Spins until lock is acquired
+# Spins until lock is acquired, with stale lock detection
+# Args:
+#   $1 - lock directory path
+#   $2 - max age in seconds before lock is considered stale (default: 60)
 lock_file() {
   local lockdir="$1"
+  local max_age="${2:-60}"
+  
   while ! mkdir "$lockdir" 2>/dev/null; do
+    # Check if existing lock is stale (older than max_age)
+    if [[ -d "$lockdir" ]]; then
+      local lock_mtime now lock_age
+      # Cross-platform mtime: Linux uses -c %Y, macOS uses -f %m
+      lock_mtime=$(stat -c %Y "$lockdir" 2>/dev/null) || lock_mtime=$(stat -f %m "$lockdir" 2>/dev/null) || lock_mtime=0
+      now=$(date +%s)
+      lock_age=$((now - lock_mtime))
+      
+      if [[ $lock_age -gt $max_age ]]; then
+        # Lock is stale - try to remove it and retry
+        rmdir "$lockdir" 2>/dev/null || true
+        continue
+      fi
+    fi
     sleep 0.1
   done
 }

--- a/lib/ocdc-up
+++ b/lib/ocdc-up
@@ -48,6 +48,7 @@ set -euo pipefail
 # Source paths library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/ocdc-paths.bash"
+source "${SCRIPT_DIR}/../lib/ocdc-file-lock.bash"
 
 # Run migration on first use
 ocdc_migrate_paths
@@ -57,6 +58,7 @@ CONFIG_DIR="$OCDC_CONFIG_DIR"
 CONFIG_FILE="$OCDC_CONFIG_FILE"
 CACHE_DIR="$OCDC_CACHE_DIR"
 PORTS_FILE="$OCDC_PORTS_FILE"
+PORTS_LOCK="${CACHE_DIR}/ports.lock"
 OVERRIDES_DIR="$OCDC_OVERRIDES_DIR"
 CLONES_DIR="$OCDC_CLONES_DIR"
 
@@ -276,15 +278,20 @@ get_port() {
   fi
 }
 
-PORT=$(get_port)
-
-# Save port assignment
+# Save port assignment (must be called while holding PORTS_LOCK)
 save_port() {
   local tmp=$(mktemp)
   jq --arg ws "$WORKSPACE" --argjson port "$PORT" --arg repo "$REPO_NAME" --arg branch "${BRANCH:-$(git -C "$WORKSPACE" branch --show-current 2>/dev/null || echo 'main')}" \
     '.[$ws] = {"port": $port, "repo": $repo, "branch": $branch, "started": now | todate}' \
     "$PORTS_FILE" > "$tmp" && mv "$tmp" "$PORTS_FILE"
 }
+
+# Atomic port reservation: find available port and save assignment
+# This prevents race conditions when multiple ocdc up commands run simultaneously
+lock_file "$PORTS_LOCK"
+PORT=$(get_port)
+save_port
+unlock_file "$PORTS_LOCK"
 
 # Read the original devcontainer.json to find the internal port
 DEVCONTAINER_JSON="$WORKSPACE/.devcontainer/devcontainer.json"
@@ -353,9 +360,6 @@ if [[ "$REMOVE_EXISTING" == "true" ]]; then
   log "Removing existing container..."
 fi
 
-# Save port assignment before starting
-save_port
-
 log "Starting devcontainer..."
 echo ""
 
@@ -388,8 +392,12 @@ if devcontainer up "${UP_ARGS[@]}"; then
   log "  ocdc list           - List all instances"
   [[ -n "$BRANCH" ]] && log "  ocdc go $BRANCH     - Navigate to this clone"
 else
-  # Clean up port assignment on failure
+  # Clean up port assignment on failure (with lock to prevent race conditions)
+  lock_file "$PORTS_LOCK"
   tmp=$(mktemp)
-  jq --arg ws "$WORKSPACE" 'del(.[$ws])' "$PORTS_FILE" > "$tmp" && mv "$tmp" "$PORTS_FILE"
+  # Use || true to ensure unlock happens even if jq/mv fails
+  { jq --arg ws "$WORKSPACE" 'del(.[$ws])' "$PORTS_FILE" > "$tmp" && mv "$tmp" "$PORTS_FILE"; } || true
+  rm -f "$tmp" 2>/dev/null || true
+  unlock_file "$PORTS_LOCK"
   error "Failed to start devcontainer"
 fi


### PR DESCRIPTION
## Summary

- Add stale lock detection to `lock_file()` (60s default timeout) to recover from crashed processes
- Wrap port finding + saving in `ocdc-up` with lock to make port assignment atomic
- Wrap `ports.json` modifications in `ocdc-down` with lock for consistency
- Add concurrent port assignment test that validates two parallel `ocdc up` commands get different ports
- Add stale lock recovery test

Fixes #27