### PR TITLE
chore: bump version to v2.5.0

### DIFF
--- a/bin/ocdc
+++ b/bin/ocdc
@@ -23,7 +23,7 @@
 
 set -euo pipefail
 
-VERSION="2.4.0"
+VERSION="2.5.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="${SCRIPT_DIR}/../lib"
 


### PR DESCRIPTION
## Summary
- Bump version string to v2.5.0 to match the release tag