### PR TITLE
fix: use Node.js 22 for semantic-release compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 0  # Needed for semantic-release
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -56,6 +61,11 @@ jobs:
         with:
           fetch-depth: 0  # Needed for semantic-release
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v4` with Node.js 22 to test and release workflows
- Required by semantic-release 24.x which needs Node.js ^22.14.0 || >= 24.10.0