### PR TITLE
fix: remove duplicate release config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,42 +30,5 @@
   "devDependencies": {
     "@semantic-release/github": "^9.2.6",
     "semantic-release": "^25.0.2"
-  },
-  "release": {
-    "branches": [
-      "main"
-    ],
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/changelog",
-        {
-          "changelogFile": "CHANGELOG.md"
-        }
-      ],
-      [
-        "@semantic-release/github",
-        {
-          "assets": [
-            {
-              "path": "dist/devcontainer-multi.tar.gz",
-              "label": "OCDC Release Archive"
-            }
-          ]
-        }
-      ],
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "CHANGELOG.md",
-            "plugin/package.json",
-            "package.json"
-          ],
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }
-      ]
-    ]
   }
 }


### PR DESCRIPTION
- Remove duplicate release config that still referenced @semantic-release/changelog and @semantic-release/git
- Config in .releaserc.js takes precedence but the package.json references were causing module not found errors