### PR TITLE
fix: use lodash template syntax for semantic-release config

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -18,26 +18,9 @@ module.exports = {
           {
             path: 'dist/devcontainer-multi.tar.gz',
             label: 'OCDC Release Archive',
-            name: (release) => `ocdc-${release.version}.tar.gz`
+            name: 'ocdc-${nextRelease.version}.tar.gz'
           }
-        ],
-        releaseName: (release) => `OCDC ${release.version}`,
-        releaseBody: (release) => `## 🎉 Release ${release.version}
-
-### 📦 Installation
-\`\`\`bash
-brew install ocdc/tap/ocdc
-\`\`\`
-
-Or download the archive below.
-
-### 📋 Changes
-${release.notes}
-
-### 🔗 Assets
-- Binary release: \`ocdc-${release.version}.tar.gz\`
-- Homebrew formula will be automatically updated
-        `
+        ]
       }
     ]
   ]


### PR DESCRIPTION
- Replace function-style templates with lodash template syntax
- Semantic-release uses lodash templates, not JavaScript functions
- Simplify config to just use default release notes format