### PR TITLE
fix: reduce verbose output when creating devcontainer via slash command

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -239,7 +239,7 @@ export const OCDC = async ({ client }) => {
             // Workspace doesn't exist - try to create it automatically
             try {
               // Use execFileSync to avoid shell injection from target
-              const result = execFileSync('ocdc', ['up', target], {
+              execFileSync('ocdc', ['up', target], {
                 encoding: "utf-8",
                 maxBuffer: 10 * 1024 * 1024,
                 timeout: 300000, // 5 minutes for container setup
@@ -256,10 +256,9 @@ export const OCDC = async ({ client }) => {
                 return `Workspace created and session now targeting: ${newResolved.repoName}/${newResolved.branch}\n` +
                        `Workspace: ${newResolved.workspace}\n\n` +
                        `All commands will run inside this container.\n` +
-                       `Use \`/ocdc off\` to disable, or prefix with \`HOST:\` to run on host.\n\n` +
-                       `--- ocdc up output ---\n${result}`
+                       `Use \`/ocdc off\` to disable, or prefix with \`HOST:\` to run on host.`
               }
-              return `Workspace created but could not auto-target. Output:\n${result}`
+              return `Workspace created but could not auto-target.`
             } catch (err) {
               // Auto-creation failed - ask for confirmation
               if (!shouldCreate) {
@@ -290,7 +289,7 @@ export const OCDC = async ({ client }) => {
             // Container exists but not running - try to start it automatically
             try {
               // Use execFileSync to avoid shell injection from target
-              const result = execFileSync('ocdc', ['up', target], {
+              execFileSync('ocdc', ['up', target], {
                 encoding: "utf-8",
                 maxBuffer: 10 * 1024 * 1024,
                 timeout: 300000,
@@ -300,8 +299,7 @@ export const OCDC = async ({ client }) => {
               return `Container started and session now targeting: ${repoName}/${branch}\n` +
                      `Workspace: ${workspace}\n\n` +
                      `All commands will run inside this container.\n` +
-                     `Use \`/ocdc off\` to disable, or prefix with \`HOST:\` to run on host.\n\n` +
-                     `--- ocdc up output ---\n${result}`
+                     `Use \`/ocdc off\` to disable, or prefix with \`HOST:\` to run on host.`
             } catch (err) {
               // Auto-start failed - ask for confirmation
               if (!shouldCreate) {

--- a/test/test_plugin.bash
+++ b/test/test_plugin.bash
@@ -650,6 +650,16 @@ test_plugin_set_context_validates_workspace() {
   return 0
 }
 
+test_plugin_ocdc_tool_does_not_show_verbose_up_output() {
+  # The ocdc tool should NOT include verbose "ocdc up output" sections
+  # These logs are noisy and not useful for the user
+  if grep -q -- '--- ocdc up output ---' "$PLUGIN_DIR/index.js"; then
+    echo "ocdc tool should not include verbose 'ocdc up output' sections"
+    return 1
+  fi
+  return 0
+}
+
 # =============================================================================
 # Timeout Utility Tests
 # =============================================================================
@@ -1683,7 +1693,8 @@ for test_func in \
   test_plugin_hook_wraps_with_ocdc_exec \
   test_plugin_ocdc_tool_checks_cli_installed \
   test_plugin_ocdc_tool_handles_off \
-  test_plugin_set_context_validates_workspace
+  test_plugin_set_context_validates_workspace \
+  test_plugin_ocdc_tool_does_not_show_verbose_up_output
 do
   setup
   run_test "${test_func#test_}" "$test_func"


### PR DESCRIPTION
## Summary

- Remove verbose `ocdc up` output from success messages when creating or starting devcontainers via `/ocdc` slash command
- Users now see clean, concise confirmation messages without container build logs
- Error messages still include diagnostic info when operations fail
- Add regression test to prevent re-adding verbose output