### PR TITLE
feat(ocdc): add branch identifier support for exec and go commands

### DIFF
--- a/lib/ocdc-exec
+++ b/lib/ocdc-exec
@@ -3,18 +3,25 @@
 # ocdc-exec - Execute a command in a running devcontainer
 #
 # Usage:
-#   ocdc exec <command> [args...]   # Run command in current workspace's container
-#   ocdc exec --workspace <path> <command> [args...]
+#   ocdc exec <branch> -- <command> [args...]   # Run in workspace by branch
+#   ocdc exec --repo <repo> <branch> -- <command> [args...]  # Specify repo
+#   ocdc exec -- <command> [args...]            # Run in current workspace
+#   ocdc exec --workspace <path> -- <command> [args...]  # Explicit path
 #
 # Examples:
-#   ocdc exec bash                  # Open shell in container
-#   ocdc exec bin/rails console    # Run rails console
-#   ocdc exec npm test             # Run tests
+#   ocdc exec feature-x -- bin/dev        # Run in feature-x branch workspace
+#   ocdc exec --repo myapp main -- bash   # Run in myapp/main workspace
+#   ocdc exec -- npm test                 # Run in current directory's workspace
+#
+# Options:
+#   --repo, -r <repo>      Specify repository (for disambiguation)
+#   --workspace, -w <path> Specify workspace path directly (takes precedence)
 #
 # Related commands:
 #   ocdc up     - Start devcontainer
 #   ocdc down   - Stop devcontainer
 #   ocdc list   - List active instances
+#   ocdc go     - Navigate to clone
 
 set -euo pipefail
 
@@ -29,8 +36,15 @@ OVERRIDES_DIR="$OCDC_OVERRIDES_DIR"
 error() { echo "[ocdc-exec] ERROR: $*" >&2; exit 1; }
 
 # Parse arguments
+# Two modes:
+# 1. With "--": ocdc exec <branch> -- <cmd>  (identifier before --, command after)
+# 2. Without "--": ocdc exec <cmd>           (all args are command, use current dir)
 WORKSPACE=""
+REPO=""
+IDENTIFIER=""
 CMD_ARGS=()
+PRE_SEPARATOR_ARGS=()
+SEEN_SEPARATOR=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -38,35 +52,63 @@ while [[ $# -gt 0 ]]; do
       WORKSPACE="$2"
       shift 2
       ;;
+    --repo|-r)
+      REPO="$2"
+      shift 2
+      ;;
     --help|-h)
       sed -n '2,/^$/p' "$0" | sed 's/^# //' | sed 's/^#//'
       exit 0
       ;;
     --)
+      SEEN_SEPARATOR=true
       shift
       CMD_ARGS+=("$@")
       break
       ;;
+    -*)
+      error "Unknown option: $1"
+      ;;
     *)
-      CMD_ARGS+=("$1")
+      # Collect non-option args before --
+      PRE_SEPARATOR_ARGS+=("$1")
       shift
       ;;
   esac
 done
 
-[[ ${#CMD_ARGS[@]} -gt 0 ]] || error "No command specified. Usage: ocdc exec <command> [args...]"
+# Interpret pre-separator args based on whether -- was seen
+if [[ "$SEEN_SEPARATOR" == "true" ]]; then
+  # With "--": pre-separator arg is the identifier
+  if [[ ${#PRE_SEPARATOR_ARGS[@]} -gt 1 ]]; then
+    error "Too many arguments before '--'. Usage: ocdc exec <branch> -- <command>"
+  elif [[ ${#PRE_SEPARATOR_ARGS[@]} -eq 1 ]]; then
+    IDENTIFIER="${PRE_SEPARATOR_ARGS[0]}"
+  fi
+  # CMD_ARGS already set from after --
+else
+  # Without "--": all pre-separator args are the command (backward compatible)
+  CMD_ARGS=("${PRE_SEPARATOR_ARGS[@]}")
+fi
+
+[[ ${#CMD_ARGS[@]} -gt 0 ]] || error "No command specified. Usage: ocdc exec <branch> -- <command>"
 
 # Determine workspace
-if [[ -z "$WORKSPACE" ]]; then
+if [[ -n "$WORKSPACE" ]]; then
+  # Explicit workspace path takes precedence
+  WORKSPACE=$(ocdc_resolve_path "$WORKSPACE")
+elif [[ -n "$IDENTIFIER" ]]; then
+  # Resolve identifier to workspace
+  WORKSPACE=$(ocdc_resolve_identifier "$IDENTIFIER" "$REPO") || exit 1
+else
+  # Fall back to current directory / git root
   if git rev-parse --git-dir >/dev/null 2>&1; then
     WORKSPACE=$(git rev-parse --show-toplevel)
   else
     WORKSPACE=$(pwd)
   fi
+  WORKSPACE=$(ocdc_resolve_path "$WORKSPACE")
 fi
-
-# Resolve to absolute path with symlinks resolved
-WORKSPACE=$(ocdc_resolve_path "$WORKSPACE")
 
 # Check if workspace is tracked
 if ! jq -e --arg ws "$WORKSPACE" '.[$ws]' "$PORTS_FILE" >/dev/null 2>&1; then

--- a/lib/ocdc-go
+++ b/lib/ocdc-go
@@ -3,14 +3,20 @@
 # ocdc-go - Navigate to an existing devcontainer clone
 #
 # Usage:
-#   ocdc go                    # List available clones for current repo
-#   ocdc go <branch>           # Go to specific branch clone
-#   ocdc go --vscode <branch>  # Open in VS Code instead of printing cd
+#   ocdc go                         # List available clones for current repo
+#   ocdc go <branch>                # Go to specific branch clone
+#   ocdc go --repo <repo> <branch>  # Specify repo for disambiguation
+#   ocdc go --vscode <branch>       # Open in VS Code instead of printing cd
+#
+# Options:
+#   --repo, -r <repo>      Specify repository (for disambiguation)
+#   --vscode, -v           Open in VS Code instead of printing cd command
 #
 # Examples:
-#   ocdc go feature-x          # Print: cd ~/.cache/devcontainer-clones/myapp/feature-x
-#   ocdc go --vscode feature-x # Opens VS Code in that directory
-#   eval $(ocdc go feature-x)  # Actually cd to the directory
+#   ocdc go feature-x               # Print: cd ~/.cache/devcontainer-clones/myapp/feature-x
+#   ocdc go --repo myapp main       # Go to myapp's main branch clone
+#   ocdc go --vscode feature-x      # Opens VS Code in that directory
+#   eval $(ocdc go feature-x)       # Actually cd to the directory
 #
 # In VS Code terminal, automatically opens VS Code window.
 # In other terminals, prints the cd command (pipe to eval to execute).
@@ -19,6 +25,7 @@
 #   ocdc up     - Start devcontainer (creates clone if needed)
 #   ocdc list   - List active instances
 #   ocdc down   - Stop container
+#   ocdc exec   - Execute command in container
 
 set -euo pipefail
 
@@ -35,10 +42,15 @@ error() { echo "[ocdc-go] ERROR: $*" >&2; exit 1; }
 
 # Parse arguments
 BRANCH=""
+REPO=""
 FORCE_VSCODE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --repo|-r)
+      REPO="$2"
+      shift 2
+      ;;
     --vscode|-v)
       FORCE_VSCODE=true
       shift
@@ -89,16 +101,21 @@ list_clones() {
 
 # If no branch specified, list available and maybe select
 if [[ -z "$BRANCH" ]]; then
-  REPO=$(get_current_repo)
-  
-  if [[ -z "$REPO" ]]; then
-    error "Not in a git repository. Specify a branch or run from within a repo."
+  # Use --repo if provided, otherwise get from current directory
+  if [[ -n "$REPO" ]]; then
+    CURRENT_REPO="$REPO"
+  else
+    CURRENT_REPO=$(get_current_repo)
   fi
   
-  log "Available clones for $REPO:"
+  if [[ -z "$CURRENT_REPO" ]]; then
+    error "Not in a git repository. Specify a branch or use --repo."
+  fi
+  
+  log "Available clones for $CURRENT_REPO:"
   echo ""
   
-  clones=$(list_clones "$REPO")
+  clones=$(list_clones "$CURRENT_REPO")
   if [[ -z "$clones" ]]; then
     log "No clones found. Create one with: ocdc up <branch>"
     exit 0
@@ -116,22 +133,49 @@ if [[ -z "$BRANCH" ]]; then
 fi
 
 # Find the clone path
-REPO=$(get_current_repo)
-if [[ -z "$REPO" ]]; then
-  # Try to find the branch in any repo's clones
-  for repo_dir in "$CLONES_DIR"/*/; do
-    [[ -d "$repo_dir" ]] || continue
-    if [[ -d "${repo_dir}${BRANCH}" ]]; then
-      WORKSPACE="${repo_dir}${BRANCH}"
-      break
-    fi
-  done
-else
+# Priority: --repo flag > tracked workspace resolution > current repo > search all repos
+
+WORKSPACE=""
+
+if [[ -n "$REPO" ]]; then
+  # Explicit repo specified
   WORKSPACE="${CLONES_DIR}/${REPO}/${BRANCH}"
+else
+  # Try to resolve via ports.json (uses shared resolution with warnings)
+  # Note: warnings go to stderr and should flow through to user
+  if resolved_ws=$(ocdc_resolve_identifier "$BRANCH" ""); then
+    # Successfully resolved - use it if the directory exists
+    if [[ -d "$resolved_ws" ]]; then
+      WORKSPACE="$resolved_ws"
+    fi
+  fi
+  
+  # Fall back to current repo if not resolved
+  if [[ -z "$WORKSPACE" ]]; then
+    CURRENT_REPO=$(get_current_repo)
+    if [[ -n "$CURRENT_REPO" ]] && [[ -d "${CLONES_DIR}/${CURRENT_REPO}/${BRANCH}" ]]; then
+      WORKSPACE="${CLONES_DIR}/${CURRENT_REPO}/${BRANCH}"
+    fi
+  fi
+  
+  # Last resort: search all repos
+  if [[ -z "$WORKSPACE" ]]; then
+    for repo_dir in "$CLONES_DIR"/*/; do
+      [[ -d "$repo_dir" ]] || continue
+      if [[ -d "${repo_dir}${BRANCH}" ]]; then
+        WORKSPACE="${repo_dir}${BRANCH}"
+        break
+      fi
+    done
+  fi
 fi
 
-if [[ -z "${WORKSPACE:-}" ]] || [[ ! -d "$WORKSPACE" ]]; then
-  error "Clone not found for branch '$BRANCH'. Create it with: ocdc up $BRANCH"
+if [[ -z "$WORKSPACE" ]] || [[ ! -d "$WORKSPACE" ]]; then
+  if [[ -n "$REPO" ]]; then
+    error "Clone not found for '$REPO/$BRANCH'. Create it with: ocdc up --repo $REPO $BRANCH"
+  else
+    error "Clone not found for branch '$BRANCH'. Create it with: ocdc up $BRANCH"
+  fi
 fi
 
 # Navigate or open

--- a/test/test_ocdc_exec.bash
+++ b/test/test_ocdc_exec.bash
@@ -78,7 +78,7 @@ EOF
   
   # This will fail because devcontainer isn't running, but it should get past the tracking check
   local output
-  output=$("$BIN_DIR/ocdc" exec --workspace "$TEST_REPO" echo hello 2>&1) || true
+  output=$("$BIN_DIR/ocdc" exec --workspace "$TEST_REPO" -- echo hello 2>&1) || true
   
   # Should not complain about tracking
   if [[ "$output" == *"No devcontainer tracked"* ]]; then
@@ -86,6 +86,133 @@ EOF
     return 1
   fi
   return 0
+}
+
+# =============================================================================
+# Branch Identifier Tests
+# =============================================================================
+
+test_ocdc_exec_resolves_branch_identifier() {
+  # Set up ports.json with a workspace
+  cat > "$TEST_CACHE_DIR/ports.json" << 'EOF'
+{
+  "/path/to/feature-branch": {
+    "port": 13000,
+    "repo": "myrepo",
+    "branch": "feature-branch",
+    "started": "2024-01-01T10:00:00Z"
+  }
+}
+EOF
+  
+  # This will fail at devcontainer exec, but should get past identifier resolution
+  local output
+  output=$("$BIN_DIR/ocdc" exec feature-branch -- echo hello 2>&1) || true
+  
+  # Should NOT say "No workspace found"
+  if [[ "$output" == *"No workspace found"* ]]; then
+    echo "Should have resolved the branch identifier"
+    echo "Output: $output"
+    return 1
+  fi
+  return 0
+}
+
+test_ocdc_exec_resolves_branch_with_repo_flag() {
+  # Set up ports.json with two workspaces, same branch different repos
+  cat > "$TEST_CACHE_DIR/ports.json" << 'EOF'
+{
+  "/path/to/repo1/main": {
+    "port": 13000,
+    "repo": "repo1",
+    "branch": "main",
+    "started": "2024-01-01T10:00:00Z"
+  },
+  "/path/to/repo2/main": {
+    "port": 13001,
+    "repo": "repo2",
+    "branch": "main",
+    "started": "2024-01-01T11:00:00Z"
+  }
+}
+EOF
+  
+  # Should resolve to repo1 when --repo is specified
+  local output
+  output=$("$BIN_DIR/ocdc" exec --repo repo1 main -- echo hello 2>&1) || true
+  
+  # Should NOT say "No workspace found"
+  if [[ "$output" == *"No workspace found"* ]]; then
+    echo "Should have resolved with --repo flag"
+    echo "Output: $output"
+    return 1
+  fi
+  
+  # Should NOT warn about ambiguity (because repo was specified)
+  if [[ "$output" == *"Multiple workspaces match"* ]]; then
+    echo "Should not warn when repo is explicitly specified"
+    echo "Output: $output"
+    return 1
+  fi
+  return 0
+}
+
+test_ocdc_exec_errors_on_unknown_branch() {
+  echo '{}' > "$TEST_CACHE_DIR/ports.json"
+  
+  local output
+  if output=$("$BIN_DIR/ocdc" exec nonexistent-branch -- echo hello 2>&1); then
+    echo "Should have failed for unknown branch"
+    return 1
+  fi
+  
+  assert_contains "$output" "No workspace found"
+}
+
+test_ocdc_exec_without_separator_uses_current_dir() {
+  # Without --, all args are treated as the command and current dir is used
+  cd "$TEST_REPO"
+  
+  local output
+  if output=$("$BIN_DIR/ocdc" exec feature echo hello 2>&1); then
+    echo "Should have failed (untracked workspace)"
+    return 1
+  fi
+  
+  # Should try to use current dir (which is untracked), not resolve "feature" as branch
+  assert_contains "$output" "No devcontainer tracked"
+}
+
+test_ocdc_exec_with_separator_uses_identifier() {
+  # With --, arg before separator is the identifier
+  cat > "$TEST_CACHE_DIR/ports.json" << 'EOF'
+{
+  "/path/to/feature": {
+    "port": 13000,
+    "repo": "myrepo",
+    "branch": "feature",
+    "started": "2024-01-01T10:00:00Z"
+  }
+}
+EOF
+  
+  # With --, "feature" is the identifier
+  local output
+  output=$("$BIN_DIR/ocdc" exec feature -- echo hello 2>&1) || true
+  
+  # Should NOT say "No devcontainer tracked" for current dir
+  # (it should have resolved "feature" to /path/to/feature)
+  if [[ "$output" == *"No devcontainer tracked for:"*"$TEST_REPO"* ]]; then
+    echo "Should have used identifier, not current dir"
+    echo "Output: $output"
+    return 1
+  fi
+  return 0
+}
+
+test_ocdc_exec_help_shows_identifier_usage() {
+  local output=$("$BIN_DIR/ocdc" exec --help 2>&1)
+  assert_contains "$output" "--repo"
 }
 
 # =============================================================================
@@ -98,7 +225,13 @@ for test_func in \
   test_ocdc_exec_shows_help \
   test_ocdc_exec_requires_command \
   test_ocdc_exec_errors_when_not_tracked \
-  test_ocdc_exec_accepts_workspace_flag
+  test_ocdc_exec_accepts_workspace_flag \
+  test_ocdc_exec_resolves_branch_identifier \
+  test_ocdc_exec_resolves_branch_with_repo_flag \
+  test_ocdc_exec_errors_on_unknown_branch \
+  test_ocdc_exec_without_separator_uses_current_dir \
+  test_ocdc_exec_with_separator_uses_identifier \
+  test_ocdc_exec_help_shows_identifier_usage
 do
   setup
   run_test "${test_func#test_}" "$test_func"

--- a/test/test_ocdc_go.bash
+++ b/test/test_ocdc_go.bash
@@ -97,6 +97,75 @@ test_ocdc_go_fails_outside_repo_without_branch() {
 }
 
 # =============================================================================
+# Repo Flag Tests
+# =============================================================================
+
+test_ocdc_go_help_shows_repo_flag() {
+  local output=$("$BIN_DIR/ocdc" go --help 2>&1)
+  assert_contains "$output" "--repo"
+}
+
+test_ocdc_go_resolves_with_repo_flag() {
+  # Create clone directories for two repos with same branch name
+  mkdir -p "$TEST_CLONES_DIR/repo1/main"
+  mkdir -p "$TEST_CLONES_DIR/repo2/main"
+  
+  # Unset TERM_PROGRAM to avoid VS Code detection
+  unset TERM_PROGRAM
+  
+  cd "$TEST_DIR"  # Not in a git repo
+  local output=$("$BIN_DIR/ocdc" go --repo repo1 main 2>&1)
+  
+  # Should output cd command to repo1's clone
+  assert_contains "$output" "cd "
+  assert_contains "$output" "repo1/main"
+}
+
+test_ocdc_go_repo_flag_short_form() {
+  mkdir -p "$TEST_CLONES_DIR/myrepo/feature"
+  
+  unset TERM_PROGRAM
+  
+  cd "$TEST_DIR"
+  local output=$("$BIN_DIR/ocdc" go -r myrepo feature 2>&1)
+  
+  assert_contains "$output" "cd "
+  assert_contains "$output" "myrepo/feature"
+}
+
+test_ocdc_go_warns_on_ambiguous_branch() {
+  # Create ports.json with two workspaces same branch different repos
+  cat > "$TEST_CACHE_DIR/ports.json" << 'EOF'
+{
+  "/test/clones/repo1/develop": {
+    "port": 13000,
+    "repo": "repo1",
+    "branch": "develop",
+    "started": "2024-01-01T10:00:00Z"
+  },
+  "/test/clones/repo2/develop": {
+    "port": 13001,
+    "repo": "repo2",
+    "branch": "develop",
+    "started": "2024-01-02T10:00:00Z"
+  }
+}
+EOF
+  
+  # Create the clone directories
+  mkdir -p "$TEST_CLONES_DIR/repo1/develop"
+  mkdir -p "$TEST_CLONES_DIR/repo2/develop"
+  
+  unset TERM_PROGRAM
+  
+  cd "$TEST_DIR"
+  local output=$("$BIN_DIR/ocdc" go develop 2>&1)
+  
+  # Should warn about ambiguity
+  assert_contains "$output" "Multiple workspaces match"
+}
+
+# =============================================================================
 # Run Tests
 # =============================================================================
 
@@ -109,7 +178,11 @@ for test_func in \
   test_ocdc_go_lists_existing_clones \
   test_ocdc_go_errors_on_missing_clone \
   test_ocdc_go_outputs_cd_command \
-  test_ocdc_go_fails_outside_repo_without_branch
+  test_ocdc_go_fails_outside_repo_without_branch \
+  test_ocdc_go_help_shows_repo_flag \
+  test_ocdc_go_resolves_with_repo_flag \
+  test_ocdc_go_repo_flag_short_form \
+  test_ocdc_go_warns_on_ambiguous_branch
 do
   setup
   run_test "${test_func#test_}" "$test_func"


### PR DESCRIPTION
## Summary

- Allow `ocdc exec` and `ocdc go` to work from anywhere by accepting a branch identifier
- Add `--repo` flag for disambiguation when multiple repos have the same branch name
- Add shared `ocdc_resolve_identifier()` function for workspace lookup
- Prefer active containers, fall back to most recently started, warn on ambiguity

## New Usage

```bash
# From anywhere
ocdc exec fix-title-box -- bin/dev           # Run in workspace by branch
ocdc exec --repo odin fix-title-box -- bin/dev  # Specify repo
ocdc go fix-title-box                        # Navigate to workspace
ocdc go --repo odin fix-title-box            # Specify repo
```

## Backward Compatible

Existing syntax still works:
- `ocdc exec bin/dev` from within workspace
- `ocdc go feature-branch` from within repo