### PR TITLE
feat: add workflow to update Homebrew formula on release

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,28 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.HOMEBREW_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_APP_PRIVATE_KEY }}
+          owner: athal7
+          repositories: homebrew-tap
+
+      - name: Update Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: ocdc
+          homebrew-tap: athal7/homebrew-tap
+          tag-name: ${{ github.event.release.tag_name }}
+          create-pullrequest: false
+        env:
+          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically updates the Homebrew formula in `athal7/homebrew-tap` when a new release is published
- Uses `mislav/bump-homebrew-formula-action` with GitHub App authentication (no PAT required)

## Setup Required
After merging, configure the GitHub App:
1. Create a GitHub App with Contents (Read & Write) permission
2. Install the app on `homebrew-tap`, `ocdc`, and `opencode-ntfy` repos
3. Add to this repo:
   - Variable: `HOMEBREW_APP_ID` 
   - Secret: `HOMEBREW_APP_PRIVATE_KEY`