### PR TITLE
fix: use push-to parameter to avoid fork requirement

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -23,6 +23,6 @@ jobs:
           formula-name: ocdc
           homebrew-tap: athal7/homebrew-tap
           tag-name: ${{ github.event.release.tag_name }}
-          create-pullrequest: false
+          push-to: athal7/homebrew-tap
         env:
           COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Add `push-to` parameter to directly push to homebrew-tap instead of forking
- Fixes "Resource not accessible by integration" error when updating formula