### PR TITLE
fix: use create-pullrequest false for direct push to main

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -23,6 +23,8 @@ jobs:
           formula-name: ocdc
           homebrew-tap: athal7/homebrew-tap
           tag-name: ${{ github.event.release.tag_name }}
-          push-to: athal7/homebrew-tap
+          create-pullrequest: false
+          commit-message: |
+            chore: bump {{formulaName}} to {{version}}
         env:
           COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Remove `push-to` param which was still creating PRs
- Use only `create-pullrequest: false` for direct push to main branch
- Add proper commit message format