### PR TITLE
fix: add base-branch parameter for direct push

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -23,8 +23,10 @@ jobs:
           formula-name: ocdc
           homebrew-tap: athal7/homebrew-tap
           tag-name: ${{ github.event.release.tag_name }}
+          push-to: athal7/homebrew-tap
           base-branch: main
           create-pullrequest: false
+          create-branch: false
           commit-message: |
             chore: bump {{formulaName}} to {{version}}
         env:


### PR DESCRIPTION
## Summary
- Add `base-branch: main` parameter to ensure direct push works correctly