### PR TITLE
fix(poll): extract repository info from URL when object is empty

### DIFF
--- a/lib/ocdc-mcp-fetch.js
+++ b/lib/ocdc-mcp-fetch.js
@@ -72,12 +72,7 @@ const TOOL_MAPPINGS = {
         title: item.title,
         body: item.body,
         html_url: item.html_url || item.url,
-        repository: {
-          full_name:
-            item.repository?.full_name ||
-            `${item.repository?.owner?.login || item.repository?.owner}/${item.repository?.name}`,
-          name: item.repository?.name,
-        },
+        repository: extractRepository(item),
         labels: item.labels || [],
         assignees: item.assignees || [],
       }));
@@ -114,10 +109,7 @@ const TOOL_MAPPINGS = {
         title: item.title,
         body: item.body,
         html_url: item.html_url || item.url,
-        repository: {
-          full_name: item.repository?.full_name,
-          name: item.repository?.name,
-        },
+        repository: extractRepository(item),
         labels: item.labels || [],
         // GitHub search API doesn't return head.ref, use fallback branch name
         headRefName: item.head?.ref || `pr-${item.number}`,
@@ -169,6 +161,53 @@ const TOOL_MAPPINGS = {
     },
   },
 };
+
+/**
+ * Extract repository info from GitHub API response
+ * Handles multiple formats: repository object, repository_url string, html_url
+ */
+function extractRepository(item) {
+  // If repository object has full_name, use it
+  if (item.repository?.full_name) {
+    return {
+      full_name: item.repository.full_name,
+      name: item.repository.name,
+    };
+  }
+  
+  // Try to build from repository object parts
+  if (item.repository?.owner && item.repository?.name) {
+    const owner = item.repository.owner?.login || item.repository.owner;
+    return {
+      full_name: `${owner}/${item.repository.name}`,
+      name: item.repository.name,
+    };
+  }
+  
+  // Extract from repository_url (e.g., "https://api.github.com/repos/owner/repo")
+  if (item.repository_url) {
+    const match = item.repository_url.match(/repos\/([^/]+\/[^/]+)$/);
+    if (match) {
+      const full_name = match[1];
+      const name = full_name.split('/')[1];
+      return { full_name, name };
+    }
+  }
+  
+  // Extract from html_url (e.g., "https://github.com/owner/repo/...")
+  if (item.html_url || item.url) {
+    const url = item.html_url || item.url;
+    const match = url.match(/github\.com\/([^/]+\/[^/]+)/);
+    if (match) {
+      const full_name = match[1];
+      const name = full_name.split('/')[1];
+      return { full_name, name };
+    }
+  }
+  
+  // Fallback to empty
+  return { full_name: "", name: "" };
+}
 
 /**
  * Parse JSON text as an array with error handling


### PR DESCRIPTION
## Summary

- Add extractRepository helper to handle multiple GitHub API response formats
- Fix empty repository object when using MCP GitHub server's search_issues tool

GitHub search API returns `repository_url` (a URL string) instead of a `repository` object. The MCP server passes this through, resulting in empty repository info.

Fixes #75