### PR TITLE
fix(poll): separate stdout/stderr in fetch and fix cross-platform sed

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -18,11 +18,11 @@ module.exports = {
       }
     ],
     
-    // Update VERSION in bin/ocdc
+    // Update VERSION in bin/ocdc (use perl for cross-platform in-place edit)
     [
       '@semantic-release/exec',
       {
-        prepareCmd: "sed -i '' 's/^VERSION=\".*\"/VERSION=\"${nextRelease.version}\"/' bin/ocdc"
+        prepareCmd: "perl -i -pe 's/^VERSION=\".*\"/VERSION=\"${nextRelease.version}\"/' bin/ocdc"
       }
     ],
     

--- a/lib/ocdc-poll
+++ b/lib/ocdc-poll
@@ -533,11 +533,17 @@ process_poll() {
   # Execute fetch command
   log "  Fetching items..."
   [[ "$VERBOSE" == "true" ]] && log "  Command: $fetch_cmd"
-  local items_json
-  if ! items_json=$(bash -c "$fetch_cmd" 2>&1); then
-    log_error "  Fetch command failed: $items_json"
+  local items_json fetch_stderr fetch_exit
+  # Capture stdout and stderr separately - MCP servers may output to stderr
+  fetch_stderr=$(mktemp)
+  items_json=$(bash -c "$fetch_cmd" 2>"$fetch_stderr")
+  fetch_exit=$?
+  if [[ $fetch_exit -ne 0 ]]; then
+    log_error "  Fetch command failed: $(cat "$fetch_stderr")"
+    rm -f "$fetch_stderr"
     return 1
   fi
+  rm -f "$fetch_stderr"
   
   # Check if we got valid JSON array
   local item_count

--- a/lib/ocdc-poll-defaults.bash
+++ b/lib/ocdc-poll-defaults.bash
@@ -164,7 +164,7 @@ poll_config_get_default_fetch_options() {
     linear_issue)
       cat << 'EOF'
 {
-  "assignee": "@me",
+  "assignee": null,
   "state": ["started", "unstarted"],
   "exclude_labels": [],
   "team": null
@@ -174,7 +174,7 @@ EOF
     github_issue)
       cat << 'EOF'
 {
-  "assignee": "@me",
+  "assignee": null,
   "state": "open",
   "labels": [],
   "repo": null,

--- a/share/ocdc/examples/github-issues.yaml
+++ b/share/ocdc/examples/github-issues.yaml
@@ -32,17 +32,21 @@
 #     }
 #   }
 #
-# Fetch options (defaults shown):
+# Fetch options:
 #   fetch:
-#     assignee: "@me"          # Issues assigned to you
+#     assignee: "@me"          # Issues assigned to you (use null for any)
 #     state: "open"            # open, closed, or all
-#     labels: []               # Filter by labels
-#     repo: null               # Single repo (owner/repo)
-#     repos: null              # Multiple repos (array of owner/repo)
-#     org: null                # Filter by organization
+#     labels: ["bug"]          # Filter by labels
+#     repo: "owner/repo"       # Single repo
+#     repos: ["o/r1", "o/r2"]  # Multiple repos
+#     org: "myorg"             # Filter by organization
 
 id: github-issues
 source_type: github_issue
+
+# Fetch issues assigned to me
+fetch:
+  assignee: "@me"
 
 # Map GitHub repos/orgs/labels to local repositories
 # Most specific rule wins (repo+labels > labels > repo > org)

--- a/share/ocdc/examples/linear-assigned.yaml
+++ b/share/ocdc/examples/linear-assigned.yaml
@@ -23,15 +23,19 @@
 #     }
 #   }
 #
-# Fetch options (defaults shown):
+# Fetch options:
 #   fetch:
-#     assignee: "@me"                      # Issues assigned to you
+#     assignee: "@me"                      # Issues assigned to you (use null for any)
 #     state: ["started", "unstarted"]      # Filter by state(s)
 #     exclude_labels: []                   # Exclude issues with these labels
-#     team: null                           # Filter by team key (e.g., "ENG")
+#     team: "ENG"                          # Filter by team key
 
 id: linear-assigned
 source_type: linear_issue
+
+# Fetch issues assigned to me
+fetch:
+  assignee: "@me"
 
 # Map Linear teams/labels to local repositories
 # Most specific rule wins (team+labels > labels > team)


### PR DESCRIPTION
## Summary
- Fix poll fetch capturing stderr with stdout, causing MCP server messages to corrupt JSON
- Fix semantic-release sed command for cross-platform compatibility (macOS vs Linux)