### PR TITLE
fix: use 'where' instead of 'which' on Windows for devcontainer CLI detection

### DIFF
--- a/plugin/core/devcontainer.js
+++ b/plugin/core/devcontainer.js
@@ -68,7 +68,8 @@ async function runCommand(cmd, args, options = {}) {
  */
 export async function checkDevcontainerCli() {
   try {
-    const result = await runCommand('which', ['devcontainer'])
+    const whichCmd = process.platform === 'win32' ? 'where' : 'which'
+    const result = await runCommand(whichCmd, ['devcontainer'])
     return result.success
   } catch {
     return false


### PR DESCRIPTION
fixes #123 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the Dev Container CLI across Windows and non-Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->