### PR TITLE
fix: use basename(workspace) instead of repoName for workspaceFolder

### DIFF
--- a/plugin/core/config.js
+++ b/plugin/core/config.js
@@ -163,7 +163,7 @@ function removePortArgs(runArgs) {
 export async function generateOverrideConfig(workspace, port, repoName) {
   const baseConfig = await readDevcontainerJson(workspace) || {}
   const internalPort = detectInternalPort(baseConfig)
-  const workspaceName = repoName || basename(workspace)
+  const workspaceName = basename(workspace) || repoName 
 
   // Build override config
   // Remove forwardPorts and appPort to prevent devcontainer CLI from setting up

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -169,20 +169,35 @@ describe('generateOverrideConfig', () => {
     assert.ok(override.name.includes('13003'))
   })
 
-  test('sets correct workspaceFolder using repoName', async () => {
+  test('uses basename(workspace) for workspaceFolder', async () => {
+    // When workspace path is provided, basename(workspace) is used for workspaceFolder
     const workspace = join(testDir, 'workspace')
     const overridePath = await generateOverrideConfig(workspace, 13004, 'myrepo')
-    
+
     const override = JSON.parse(readFileSync(overridePath, 'utf-8'))
-    assert.strictEqual(override.workspaceFolder, '/workspaces/myrepo')
+    // workspaceFolder should use basename(workspace), not repoName
+    assert.strictEqual(override.workspaceFolder, '/workspaces/workspace')
   })
 
   test('falls back to basename when repoName not provided', async () => {
     const workspace = join(testDir, 'workspace')
     const overridePath = await generateOverrideConfig(workspace, 13004)
-    
+
     const override = JSON.parse(readFileSync(overridePath, 'utf-8'))
     assert.strictEqual(override.workspaceFolder, '/workspaces/workspace')
+  })
+
+  test('prefers basename(workspace) over repoName when both provided', async () => {
+    // When workspace path and repoName are both provided,
+    // basename(workspace) should take precedence for workspaceFolder
+    const workspace = join(testDir, 'my-clone')
+    const overridePath = await generateOverrideConfig(workspace, 13007, 'different-repo-name')
+
+    const override = JSON.parse(readFileSync(overridePath, 'utf-8'))
+    // workspaceFolder should use basename(workspace), not repoName
+    assert.strictEqual(override.workspaceFolder, '/workspaces/my-clone')
+    // name should also use basename(workspace)
+    assert.strictEqual(override.name, 'my-clone (port 13007)')
   })
 
   test('handles config without runArgs', async () => {


### PR DESCRIPTION
## Summary

- Fix: Use `basename(workspace)` instead of `repoName` for `workspaceFolder` and container `name` in `generateOverrideConfig`
- Test: Add test case to verify `basename(workspace)` takes precedence over `repoName` when both are provided

## Changes

### Fix (config.js)
```javascript
// Before
const workspaceName = repoName || basename(workspace)

// After
const workspaceName = basename(workspace) || repoName
```

### Test (config.test.js)
- Updated existing test to expect `basename(workspace)` for `workspaceFolder`
- Added new test `prefers basename(workspace) over repoName when both provided`

## Testing

- All 21 config tests pass

## Checklist

- [x] Tests added/updated
- [x] Tests pass (`npm test`)
- [x] Commit messages follow conventional commit format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace naming in generated configurations by prioritizing the workspace folder name.
  * Ensured workspace folder and override names remain consistent when workspace and repository names differ.
  * Added fallback behavior for cases where a repository name is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->