### PR TITLE
feat: add commands for removing devcontainers

### DIFF
--- a/plugin/command/devcontainer.md
+++ b/plugin/command/devcontainer.md
@@ -1,7 +1,9 @@
 ---
-description: Target a devcontainer - /devcontainer <branch> or off
+description: Target a devcontainer - /devcontainer <branch>, off. Or remove: /devcontainer rm <branch>, or rm all
 ---
 
-Call the `devcontainer` tool with target set to: $ARGUMENTS
+Call the `devcontainer` tool with `target` set to: $ARGUMENTS
 
 If no arguments provided, call `devcontainer` with no target to show current status.
+
+If a `rm` command returns a message asking for confirmation, ask the user if they want to proceed. If they agree, call the tool again with the same arguments plus `confirmed: true`.

--- a/plugin/core/devcontainer.js
+++ b/plugin/core/devcontainer.js
@@ -9,14 +9,15 @@
  */
 
 import { spawn } from 'child_process'
-import { basename } from 'path'
+import { join, basename } from 'path'
+import { readdirSync, readFileSync, existsSync, unlinkSync } from 'fs'
+import { unlink } from 'fs/promises'
 import { PATHS, ensureDirs } from './paths.js'
 import { allocatePort, releasePort, readPorts, getContainerPort, updatePortAllocation } from './ports.js'
 import { generateOverrideConfig, getOverridePath } from './config.js'
-import { createClone, getClonePath } from './clones.js'
+import { createClone, getClonePath, removeClone } from './clones.js'
 import { getCurrentBranch, getRepoRoot } from './git.js'
-import { startJob, updateJob, JOB_STATUS } from './jobs.js'
-import { existsSync } from 'fs'
+import { startJob, updateJob, JOB_STATUS, removeJob } from './jobs.js'
 
 /**
  * Run a command and return a promise with the result
@@ -394,6 +395,189 @@ export async function exec(workspace, command, options = {}) {
 }
 
 /**
+ * Find Docker container ID for a workspace (running or stopped)
+ * 
+ * @param {string} workspace - Workspace path
+ * @returns {Promise<string|null>} Container ID or null if not found
+ */
+async function findContainerId(workspace) {
+  try {
+    const result = await runCommand('docker', [
+      'ps', '-a',
+      '--filter', `label=devcontainer.local_folder=${workspace}`,
+      '--format', '{{.ID}}',
+    ])
+    if (result.success && result.stdout) {
+      const id = result.stdout.split('\n')[0].trim()
+      return id || null
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Clean up session files that reference a workspace
+ * 
+ * Scans the sessions directory and deletes any session files
+ * whose workspace field matches the given workspace.
+ * 
+ * @param {string} workspace - Workspace path to match
+ * @returns {number} Number of session files cleaned up
+ */
+function cleanupWorkspaceSessions(workspace) {
+  const sessionsDir = PATHS.sessions
+  if (!existsSync(sessionsDir)) return 0
+
+  let cleaned = 0
+  const files = readdirSync(sessionsDir)
+
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue
+    const filePath = join(sessionsDir, file)
+    try {
+      const content = readFileSync(filePath, 'utf-8')
+      const session = JSON.parse(content)
+      if (session.workspace === workspace) {
+        unlinkSync(filePath)
+        cleaned++
+      }
+    } catch {
+      // Skip unreadable files or invalid JSON
+    }
+  }
+
+  return cleaned
+}
+
+/**
+ * Remove a devcontainer completely
+ * 
+ * Orchestrates full cleanup:
+ * 1. Find Docker container
+ * 2. Stop Docker container
+ * 3. Get image reference
+ * 4. Remove Docker container
+ * 5. Remove Docker image
+ * 6. Release port allocation
+ * 7. Remove job entry
+ * 8. Delete override config
+ * 9. Delete clone folder
+ * 10. Clean up session files
+ * 
+ * @param {string} workspace - Absolute path to workspace
+ * @param {string} repo - Repository name
+ * @param {string} branch - Branch name
+ * @returns {Promise<{workspace: string, repo: string, branch: string, containerFound: boolean, containerStopped: boolean, containerRemoved: boolean, imageRemoved: boolean, portReleased: boolean, jobRemoved: boolean, overrideDeleted: boolean, cloneDeleted: boolean, sessionsCleaned: number, errors: string[]}>}
+ */
+export async function remove(workspace, repo, branch) {
+  const summary = {
+    workspace,
+    repo,
+    branch,
+    containerFound: false,
+    containerStopped: false,
+    containerRemoved: false,
+    imageRemoved: false,
+    portReleased: false,
+    jobRemoved: false,
+    overrideDeleted: false,
+    cloneDeleted: false,
+    sessionsCleaned: 0,
+    errors: [],
+  }
+
+  // 1. Find Docker container
+  const containerId = await findContainerId(workspace)
+  if (containerId) {
+    summary.containerFound = true
+
+    // 2. Stop container (ignore error if already stopped)
+    try {
+      await runCommand('docker', ['stop', containerId])
+      summary.containerStopped = true
+    } catch {
+      // Container might not be running
+    }
+
+    // 3. Get image ref before removing container
+    let imageRef = null
+    try {
+      const inspectResult = await runCommand('docker', [
+        'inspect', containerId,
+        '--format', '{{.Image}}',
+      ])
+      if (inspectResult.success && inspectResult.stdout) {
+        imageRef = inspectResult.stdout.trim()
+      }
+    } catch {
+      // Container may have already been removed externally
+    }
+
+    // 4. Remove container
+    try {
+      await runCommand('docker', ['rm', containerId])
+      summary.containerRemoved = true
+    } catch (err) {
+      summary.errors.push(`Failed to remove container: ${err.message}`)
+    }
+
+    // 5. Remove image (after container is removed)
+    if (imageRef) {
+      try {
+        await runCommand('docker', ['rmi', imageRef])
+        summary.imageRemoved = true
+      } catch {
+        // Image may be in use by other containers
+      }
+    }
+  }
+
+  // 6. Release port
+  try {
+    await releasePort(workspace)
+    summary.portReleased = true
+  } catch (err) {
+    summary.errors.push(`Failed to release port: ${err.message}`)
+  }
+
+  // 7. Remove job entry
+  try {
+    summary.jobRemoved = await removeJob(workspace)
+  } catch (err) {
+    summary.errors.push(`Failed to remove job: ${err.message}`)
+  }
+
+  // 8. Delete override config
+  try {
+    const overridePath = getOverridePath(workspace)
+    if (existsSync(overridePath)) {
+      await unlink(overridePath)
+      summary.overrideDeleted = true
+    }
+  } catch (err) {
+    summary.errors.push(`Failed to delete override: ${err.message}`)
+  }
+
+  // 9. Remove clone folder
+  try {
+    summary.cloneDeleted = await removeClone(repo, branch)
+  } catch (err) {
+    summary.errors.push(`Failed to remove clone: ${err.message}`)
+  }
+
+  // 10. Clean up session files
+  try {
+    summary.sessionsCleaned = cleanupWorkspaceSessions(workspace)
+  } catch (err) {
+    summary.errors.push(`Failed to clean sessions: ${err.message}`)
+  }
+
+  return summary
+}
+
+/**
  * Stop a devcontainer and release its port
  * 
  * @param {string} workspace - Workspace path
@@ -494,5 +678,6 @@ export default {
   down,
   list,
   isContainerRunning,
+  remove,
   runCommand,
 }

--- a/plugin/core/index.js
+++ b/plugin/core/index.js
@@ -30,6 +30,7 @@ export {
   checkDevcontainerCli,
   buildUpArgs,
   buildExecArgs,
+  remove,
 } from './devcontainer.js'
 
 // Job tracking for background operations
@@ -40,6 +41,7 @@ export {
   startJob,
   updateJob,
   getJob,
+  removeJob,
   cleanupJobs,
 } from './jobs.js'
 

--- a/plugin/core/jobs.js
+++ b/plugin/core/jobs.js
@@ -147,6 +147,20 @@ export async function getJob(workspace) {
 }
 
 /**
+ * Remove a job entry for a workspace
+ * 
+ * @param {string} workspace - Workspace path
+ * @returns {Promise<boolean>} True if job existed and was removed, false if not found
+ */
+export async function removeJob(workspace) {
+  const jobs = await readJobs()
+  if (!jobs[workspace]) return false
+  delete jobs[workspace]
+  await writeJobs(jobs)
+  return true
+}
+
+/**
  * Clean up old completed and failed jobs
  * 
  * @param {Object} [options]
@@ -195,5 +209,6 @@ export default {
   startJob,
   updateJob,
   getJob,
+  removeJob,
   cleanupJobs,
 }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,5 @@
 import { 
-  mkdirSync, existsSync, readdirSync, unlinkSync, copyFileSync 
+  mkdirSync, existsSync, readdirSync, unlinkSync, copyFileSync, readFileSync 
 } from "fs"
 import { join, dirname, basename } from "path"
 import { fileURLToPath } from "url"
@@ -29,6 +29,10 @@ import {
   cleanupJobs,
   JOB_STATUS,
   PATHS,
+  remove,
+  listClones,
+  readPorts,
+  readJobs,
   // Worktree imports
   createWorktreeWorkspace,
   getRepoRoot,
@@ -116,6 +120,200 @@ function buildDevcontainerExecCommand(workspace, command) {
   return cmd
 }
 
+/**
+ * Format a single remove result for display
+ */
+function formatRemoveSummary(summary) {
+  const label = `${summary.repo}/${summary.branch}`
+  let output = `Removed devcontainer: ${label}\n`
+
+  if (summary.containerFound) {
+    output += `  - Container: ${summary.containerStopped ? "stopped and " : ""}removed\n`
+    if (summary.imageRemoved) {
+      output += `  - Image: removed\n`
+    } else if (summary.containerFound) {
+      output += `  - Image: could not remove (may be in use)\n`
+    }
+  } else {
+    output += `  - Container: not found\n`
+  }
+
+  output += `  - Port: ${summary.portReleased ? "released" : "error"}\n`
+  output += `  - Job entry: ${summary.jobRemoved !== false ? "cleaned up" : "not found"}\n`
+  output += `  - Override config: ${summary.overrideDeleted ? "deleted" : "error"}\n`
+  output += `  - Clone folder: ${summary.cloneDeleted ? "deleted" : "not found"}\n`
+
+  if (summary.sessionsCleaned > 0) {
+    output += `  - Sessions: ${summary.sessionsCleaned} cleaned up\n`
+  }
+
+  if (summary.errors.length > 0) {
+    output += `  Errors:\n`
+    for (const err of summary.errors) {
+      output += `    - ${err}\n`
+    }
+  }
+
+  return output
+}
+
+/**
+ * Count other sessions (excluding current) that reference a workspace.
+ * If workspace is null, counts all other sessions regardless of workspace.
+ */
+function countOtherSessions(workspace, currentSessionID) {
+  const sessionsDir = getSessionsDir()
+  if (!existsSync(sessionsDir)) return 0
+  const files = readdirSync(sessionsDir)
+  let count = 0
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue
+    const sid = file.replace('.json', '')
+    if (sid === currentSessionID) continue
+    try {
+      const data = JSON.parse(readFileSync(join(sessionsDir, file), 'utf-8'))
+      if (workspace === null || data.workspace === workspace) count++
+    } catch {}
+  }
+  return count
+}
+
+async function handleRemoveSingle(rmArg, sessionID, confirmed) {
+  // Try to resolve workspace from branch name
+  const resolved = resolveWorkspace(rmArg)
+
+  if (!resolved) {
+    return `No devcontainer found for branch '${rmArg}'.\n\n` +
+           `Use \`/devcontainer\` to list active devcontainers or \`/devcontainer <branch>\` to set one up first.`
+  }
+
+  if (resolved.ambiguous) {
+    const options = resolved.matches
+      .map(m => `  - ${m.repoName}/${m.branch}`)
+      .join("\n")
+    return `Ambiguous branch '${rmArg}' found in multiple repos:\n${options}\n\n` +
+           `Use \`/devcontainer rm <repo>/${rmArg}\` to specify.`
+  }
+
+  const { workspace, repoName, branch } = resolved
+
+  // Pre-removal warnings (skip when already confirmed)
+  if (!confirmed) {
+    const msgs = []
+
+    try {
+      const status = await getWorkspaceStatus(workspace)
+      if (status.hasUncommitted) msgs.push("There are uncommitted changes in the workspace.")
+    } catch {}
+
+    if (countOtherSessions(workspace, sessionID) > 0) {
+      msgs.push("This workspace is active in other sessions.")
+    }
+
+    if (msgs.length > 0) {
+      return msgs.join('\n') + '\n\nAn explicit user confirmation required, it is non-negotiable.'
+    }
+  }
+
+  // Run the remove operation
+  const summary = await remove(workspace, repoName, branch)
+
+  // Clear current session if it targets this workspace
+  const session = loadSession(sessionID)
+  if (session && session.workspace === workspace) {
+    deleteSession(sessionID)
+  }
+
+  return formatRemoveSummary(summary)
+}
+
+/**
+ * Handle `/devcontainer rm all`
+ */
+async function handleRemoveAll(sessionID, confirmed) {
+  // Collect all tracked devcontainer workspaces from all sources
+  const seen = new Set()
+  const entries = []
+
+  // From clones directory
+  const clones = await listClones()
+  for (const c of clones) {
+    if (!seen.has(c.workspace)) {
+      seen.add(c.workspace)
+      entries.push(c)
+    }
+  }
+
+  // From ports.json (orphan entries not already covered)
+  const ports = await readPorts()
+  for (const [ws, data] of Object.entries(ports)) {
+    if (!seen.has(ws)) {
+      seen.add(ws)
+      entries.push({ workspace: ws, repo: data.repo, branch: data.branch })
+    }
+  }
+
+  // From jobs.json (orphan entries not already covered)
+  const jobs = await readJobs()
+  for (const [ws, data] of Object.entries(jobs)) {
+    if (!seen.has(ws)) {
+      seen.add(ws)
+      entries.push({ workspace: ws, repo: data.repo, branch: data.branch })
+    }
+  }
+
+  if (entries.length === 0) {
+    return "No devcontainers to clean up."
+  }
+
+  // Pre-removal warnings (skip when already confirmed)
+  if (!confirmed) {
+    const msgs = []
+
+    for (const entry of entries) {
+      try {
+        const status = await getWorkspaceStatus(entry.workspace)
+        if (status.hasUncommitted) {
+          msgs.push("Some workspaces have uncommitted changes.")
+          break
+        }
+      } catch {}
+    }
+
+    if (countOtherSessions(null, sessionID) > 0) {
+      msgs.push("Some workspaces are active in other sessions.")
+    }
+
+    if (msgs.length > 0) {
+      return msgs.join('\n') + '\n\nReply "yes" to confirm or "no" to cancel.'
+    }
+  }
+
+  // Remove each devcontainer
+  let output = `Removing ${entries.length} devcontainer(s)...\n\n`
+  let totalErrors = 0
+
+  for (const entry of entries) {
+    const summary = await remove(entry.workspace, entry.repo, entry.branch)
+    output += formatRemoveSummary(summary) + '\n'
+    totalErrors += summary.errors.length
+  }
+
+  // Clear current session
+  const session = loadSession(sessionID)
+  if (session) {
+    deleteSession(sessionID)
+    output += `Active session cleared.\n`
+  }
+
+  output += `\nDone. ${totalErrors} error(s) during cleanup.`
+  if (totalErrors > 0) {
+    output += ` Some containers or images may need manual cleanup via \`docker\` commands.`
+  }
+
+  return output
+}
+
 // ============ Plugin Export ============
 
 export const devcontainers = async ({ client }) => {
@@ -195,10 +393,13 @@ export const devcontainers = async ({ client }) => {
           create: tool.schema.string().optional().describe(
             "Set to 'true' to create the workspace if it doesn't exist (requires confirmation)"
           ),
+          confirmed: tool.schema.boolean().optional().describe(
+            "Set to true to confirm the remove operation after reviewing warnings about uncommitted changes or other active sessions"
+          ),
         },
         async execute(args, ctx) {
           const { sessionID, abort: signal } = ctx
-          const { target, create } = args
+          const { target, create, confirmed } = args
           const shouldCreate = create === "true" || create === true
           
           // Verify devcontainer CLI is installed
@@ -269,6 +470,21 @@ export const devcontainers = async ({ client }) => {
               return `Devcontainer mode disabled. Commands will now run on the host.`
             }
             return "No devcontainer was active for this session."
+          }
+          
+          // Remove request
+          if (target.startsWith("rm ")) {
+            const rmArg = target.slice(3).trim()
+            
+            if (!rmArg) {
+              return "Usage: `/devcontainer rm <branch>` or `/devcontainer rm all`"
+            }
+            
+            if (rmArg === "all") {
+              return await handleRemoveAll(sessionID, confirmed)
+            }
+            
+            return await handleRemoveSingle(rmArg, sessionID, confirmed)
           }
           
           // Resolve workspace (check if clone already exists)

--- a/test/integration/devcontainer-remove.test.js
+++ b/test/integration/devcontainer-remove.test.js
@@ -1,0 +1,170 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { join } from 'path'
+import { homedir } from 'os'
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { execSync } from 'child_process'
+import { createHash } from 'crypto'
+
+import { remove } from '../../plugin/core/devcontainer.js'
+import { readJobs } from '../../plugin/core/jobs.js'
+import { getOverridePath } from '../../plugin/core/config.js'
+import { PATHS } from '../../plugin/core/paths.js'
+
+const IMAGE = 'alpine:3.19'
+
+describe('remove (integration)', () => {
+  const testDir = join(homedir(), '.cache/ocdc-int-rm-' + Date.now())
+  const workspace = join(testDir, 'clones', 'my-repo', 'feature-x')
+  const repo = 'my-repo'
+  const branch = 'feature-x'
+
+  let decoyId = null
+  let devcontainerId = null
+
+  before(() => {
+    process.env.OCDC_CACHE_DIR = testDir
+    process.env.OCDC_CONFIG_DIR = join(testDir, 'config')
+    process.env.OCDC_CLONES_DIR = join(testDir, 'clones')
+
+    // Ensure alpine image is available
+    execSync(`docker pull ${IMAGE}`, { stdio: 'pipe' })
+
+    // Create complete devcontainer workspace state
+    mkdirSync(join(testDir, 'config'), { recursive: true })
+    writeFileSync(join(testDir, 'config', 'config.json'), JSON.stringify({
+      portRangeStart: 19000, portRangeEnd: 19010,
+    }))
+
+    writeFileSync(join(testDir, 'ports.json'), JSON.stringify({
+      [workspace]: { port: 19000, repo, branch, started: new Date().toISOString() },
+    }))
+
+    writeFileSync(join(testDir, 'jobs.json'), JSON.stringify({
+      [workspace]: { workspace, repo, branch, status: 'completed', startedAt: new Date().toISOString() },
+    }))
+
+    const overrideDir = join(testDir, 'overrides')
+    mkdirSync(overrideDir, { recursive: true })
+    const overrideFilename = createHash('md5').update(workspace).digest('hex') + '.json'
+    writeFileSync(join(overrideDir, overrideFilename), JSON.stringify({
+      name: 'test (port 19000)',
+      workspaceFolder: '/workspaces/test',
+    }))
+
+    mkdirSync(join(workspace, '.git'), { recursive: true })
+    writeFileSync(join(workspace, 'README.md'), '# Test')
+
+    const sessionsDir = join(testDir, 'opencode-sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    writeFileSync(join(sessionsDir, 'test-session.json'), JSON.stringify({
+      branch, workspace, repoName: repo, type: 'devcontainer',
+    }))
+    writeFileSync(join(sessionsDir, 'other-session.json'), JSON.stringify({
+      branch: 'other', workspace: '/other/workspace', repoName: 'other', type: 'devcontainer',
+    }))
+
+    // Create decoy container (plain Docker, no devcontainer label)
+    decoyId = execSync(
+      `docker run -d --name ocdc-int-test-decoy ${IMAGE} tail -f /dev/null`,
+      { encoding: 'utf-8' }
+    ).trim()
+
+    // Create devcontainer container with the label remove() uses to find it
+    devcontainerId = execSync(
+      `docker run -d --label devcontainer.local_folder=${workspace} ${IMAGE} tail -f /dev/null`,
+      { encoding: 'utf-8' }
+    ).trim()
+  })
+
+  after(() => {
+    // Force-clean any leftover containers
+    try { execSync(`docker rm -f ${decoyId}`, { stdio: 'ignore' }) } catch {}
+    try {
+      // Find and clean any remaining devcontainer-labelled containers
+      const remaining = execSync(
+        'docker ps -a -q --filter label=devcontainer.local_folder',
+        { encoding: 'utf-8' }
+      ).trim()
+      if (remaining) {
+        execSync(`docker rm -f ${remaining}`, { stdio: 'ignore' })
+      }
+    } catch {}
+
+    delete process.env.OCDC_CACHE_DIR
+    delete process.env.OCDC_CONFIG_DIR
+    delete process.env.OCDC_CLONES_DIR
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  test('removes devcontainer while leaving unrelated containers untouched', async () => {
+    // Sanity check: both containers exist and decoy is running
+    const decoyBefore = execSync(
+      `docker inspect ${decoyId} --format '{{.State.Status}}'`,
+      { encoding: 'utf-8' }
+    ).trim()
+    assert.strictEqual(decoyBefore, 'running', 'decoy should be running before remove')
+
+    const devStatusBefore = execSync(
+      `docker inspect ${devcontainerId} --format '{{.State.Status}}'`,
+      { encoding: 'utf-8' }
+    ).trim()
+    assert.strictEqual(devStatusBefore, 'running', 'devcontainer should be running before remove')
+
+    // Act
+    const summary = await remove(workspace, repo, branch)
+
+    // Assert all Docker fields are true
+    assert.strictEqual(summary.containerFound, true, 'container found')
+    assert.strictEqual(summary.containerStopped, true, 'container stopped')
+    assert.strictEqual(summary.containerRemoved, true, 'container removed')
+    assert.strictEqual(summary.imageRemoved, true, 'image removed')
+
+    // Assert all filesystem cleanup fields
+    assert.strictEqual(summary.portReleased, true)
+    assert.strictEqual(summary.jobRemoved, true)
+    assert.strictEqual(summary.overrideDeleted, true)
+    assert.strictEqual(summary.cloneDeleted, true)
+    assert.strictEqual(summary.sessionsCleaned, 1)
+
+    // Verify devcontainer container is gone
+    const remaining = execSync(
+      'docker ps -a -q --filter label=devcontainer.local_folder',
+      { encoding: 'utf-8' }
+    ).trim()
+    assert.strictEqual(remaining, '', 'no containers with devcontainer label remain')
+
+    // Verify devcontainer container ID no longer exists
+    try {
+      execSync(`docker inspect ${devcontainerId}`, { stdio: 'pipe' })
+      assert.fail('devcontainer container should no longer exist')
+    } catch {
+      // Expected — container was removed
+    }
+
+    // Verify filesystem artifacts
+    const ports = JSON.parse(readFileSync(join(testDir, 'ports.json'), 'utf-8'))
+    assert.strictEqual(ports[workspace], undefined, 'port entry removed')
+
+    const jobs = await readJobs()
+    assert.strictEqual(jobs[workspace], undefined, 'job entry removed')
+
+    assert.ok(!existsSync(getOverridePath(workspace)), 'override config deleted')
+    assert.ok(!existsSync(workspace), 'clone folder deleted')
+
+    const sessionFile = join(PATHS.sessions, 'test-session.json')
+    const otherSessionFile = join(PATHS.sessions, 'other-session.json')
+    assert.ok(!existsSync(sessionFile), 'matching session cleaned')
+    assert.ok(existsSync(otherSessionFile), 'other session preserved')
+
+    // Verify decoy is still running and untouched
+    const decoyAfter = execSync(
+      `docker inspect ${decoyId} --format '{{.State.Status}}'`,
+      { encoding: 'utf-8' }
+    ).trim()
+    assert.strictEqual(decoyAfter, 'running', 'decoy container was not affected')
+
+    // Verify no errors reported
+    assert.strictEqual(summary.errors.length, 0, JSON.stringify(summary.errors))
+  })
+})

--- a/test/unit/devcontainer.test.js
+++ b/test/unit/devcontainer.test.js
@@ -13,6 +13,7 @@ import { join, basename } from 'path'
 import { homedir } from 'os'
 import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { execSync } from 'child_process'
+import { createHash } from 'crypto'
 
 // Module under test
 import { 
@@ -24,10 +25,13 @@ import {
   list,
   down,
   isContainerRunning,
-  checkDevcontainerCli
+  checkDevcontainerCli,
+  remove
 } from '../../plugin/core/devcontainer.js'
 import { PATHS } from '../../plugin/core/paths.js'
-import { readJobs, JOB_STATUS } from '../../plugin/core/jobs.js'
+import { readJobs, JOB_STATUS, removeJob } from '../../plugin/core/jobs.js'
+import { getOverridePath } from '../../plugin/core/config.js'
+import { getClonePath } from '../../plugin/core/clones.js'
 
 describe('buildUpArgs', () => {
   test('includes workspace-folder and override-config', () => {
@@ -474,5 +478,160 @@ describe('down', () => {
   test('handles non-existent workspace', async () => {
     // Should not throw
     await down('/workspace/nonexistent')
+  })
+})
+
+describe('remove', () => {
+  const testDir = join(homedir(), '.cache/ocdc-test-remove-' + Date.now())
+  const workspace = join(testDir, 'clones', 'my-repo', 'feature-x')
+  const repo = 'my-repo'
+  const branch = 'feature-x'
+
+  /**
+   * Create a full set of workspace artifacts as if a devcontainer was set up:
+   * ports.json entry, jobs.json entry, override config, clone folder, session files
+   */
+  function createFullWorkspaceState() {
+    mkdirSync(join(testDir, 'config'), { recursive: true })
+    writeFileSync(join(testDir, 'config', 'config.json'), JSON.stringify({
+      portRangeStart: 19000,
+      portRangeEnd: 19010,
+    }))
+
+    mkdirSync(testDir, { recursive: true })
+    writeFileSync(join(testDir, 'ports.json'), JSON.stringify({
+      [workspace]: { port: 19000, repo, branch, started: '2026-01-01T00:00:00Z' },
+    }))
+
+    writeFileSync(join(testDir, 'jobs.json'), JSON.stringify({
+      [workspace]: { workspace, repo, branch, status: JOB_STATUS.COMPLETED, startedAt: '2026-01-01T00:00:00Z' },
+    }))
+
+    const overrideDir = join(testDir, 'overrides')
+    mkdirSync(overrideDir, { recursive: true })
+    const overrideFilename = createHash('md5').update(workspace).digest('hex') + '.json'
+    writeFileSync(join(overrideDir, overrideFilename), JSON.stringify({
+      name: 'test (port 19000)',
+      workspaceFolder: '/workspaces/test',
+    }))
+
+    mkdirSync(join(workspace, '.git'), { recursive: true })
+    writeFileSync(join(workspace, 'README.md'), '# Test')
+
+    const sessionsDir = join(testDir, 'opencode-sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    writeFileSync(join(sessionsDir, 'test-session.json'), JSON.stringify({
+      branch, workspace, repoName: repo, type: 'devcontainer', activatedAt: '2026-01-01T00:00:00Z',
+    }))
+    writeFileSync(join(sessionsDir, 'other-session.json'), JSON.stringify({
+      branch: 'other', workspace: '/other/workspace', repoName: 'other', type: 'devcontainer',
+    }))
+  }
+
+  beforeEach(() => {
+    process.env.OCDC_CACHE_DIR = testDir
+    process.env.OCDC_CONFIG_DIR = join(testDir, 'config')
+    process.env.OCDC_CLONES_DIR = join(testDir, 'clones')
+  })
+
+  afterEach(() => {
+    delete process.env.OCDC_CACHE_DIR
+    delete process.env.OCDC_CONFIG_DIR
+    delete process.env.OCDC_CLONES_DIR
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  test('removes all workspace components when everything exists', async () => {
+    createFullWorkspaceState()
+
+    const summary = await remove(workspace, repo, branch)
+
+    // Docker not available in unit tests — container fields are false
+    assert.strictEqual(summary.containerFound, false)
+    assert.strictEqual(summary.portReleased, true)
+    assert.strictEqual(summary.jobRemoved, true)
+    assert.strictEqual(summary.overrideDeleted, true)
+    assert.strictEqual(summary.cloneDeleted, true)
+    assert.strictEqual(summary.sessionsCleaned, 1)
+
+    // Verify filesystem artifacts are actually gone
+    const ports = JSON.parse(readFileSync(join(testDir, 'ports.json'), 'utf-8'))
+    assert.strictEqual(ports[workspace], undefined, 'port entry removed')
+
+    const jobs = await readJobs()
+    assert.strictEqual(jobs[workspace], undefined, 'job entry removed')
+
+    assert.ok(!existsSync(getOverridePath(workspace)), 'override config deleted')
+    assert.ok(!existsSync(workspace), 'clone folder deleted')
+
+    const sessionFile = join(PATHS.sessions, 'test-session.json')
+    const otherSessionFile = join(PATHS.sessions, 'other-session.json')
+    assert.ok(!existsSync(sessionFile), 'matching session cleaned up')
+    assert.ok(existsSync(otherSessionFile), 'other session preserved')
+  })
+
+  test('handles workspace with missing clone folder', async () => {
+    createFullWorkspaceState()
+    // Remove the clone folder before calling remove
+    rmSync(workspace, { recursive: true, force: true })
+
+    const summary = await remove(workspace, repo, branch)
+
+    assert.strictEqual(summary.cloneDeleted, false, 'clone was already gone')
+    assert.strictEqual(summary.portReleased, true, 'port still released')
+    assert.strictEqual(summary.jobRemoved, true, 'job still removed')
+    assert.strictEqual(summary.overrideDeleted, true, 'override still cleaned')
+    assert.strictEqual(summary.errors.length, 0, 'no errors')
+  })
+
+  test('handles workspace with no port or job entries', async () => {
+    // Only create clone folder and override, no ports/jobs entries
+    mkdirSync(join(testDir, 'overrides'), { recursive: true })
+    const overrideFilename = createHash('md5').update(workspace).digest('hex') + '.json'
+    writeFileSync(join(testDir, 'overrides', overrideFilename), JSON.stringify({ name: 'test' }))
+    mkdirSync(join(workspace, '.git'), { recursive: true })
+    writeFileSync(join(workspace, 'README.md'), '# Test')
+    mkdirSync(testDir, { recursive: true })
+    writeFileSync(join(testDir, 'ports.json'), '{}')
+    writeFileSync(join(testDir, 'jobs.json'), '{}')
+
+    const summary = await remove(workspace, repo, branch)
+
+    assert.strictEqual(summary.portReleased, true, 'releasePort called')
+    assert.strictEqual(summary.jobRemoved, false, 'no job to remove')
+    assert.strictEqual(summary.overrideDeleted, true)
+    assert.strictEqual(summary.cloneDeleted, true)
+    assert.strictEqual(summary.errors.length, 0)
+  })
+
+  test('handles completely unknown workspace gracefully', async () => {
+    mkdirSync(testDir, { recursive: true })
+    writeFileSync(join(testDir, 'ports.json'), '{}')
+    writeFileSync(join(testDir, 'jobs.json'), '{}')
+
+    const summary = await remove('/nonexistent/workspace', 'test', 'nonexistent')
+
+    assert.strictEqual(summary.containerFound, false)
+    assert.strictEqual(summary.portReleased, true)
+    assert.strictEqual(summary.jobRemoved, false)
+    assert.strictEqual(summary.overrideDeleted, false)
+    assert.strictEqual(summary.cloneDeleted, false)
+    assert.strictEqual(summary.sessionsCleaned, 0)
+    assert.strictEqual(summary.errors.length, 0)
+  })
+
+  test('removal is idempotent', async () => {
+    createFullWorkspaceState()
+
+    const first = await remove(workspace, repo, branch)
+    assert.strictEqual(first.portReleased, true)
+    assert.strictEqual(first.jobRemoved, true)
+    assert.strictEqual(first.cloneDeleted, true)
+
+    const second = await remove(workspace, repo, branch)
+    assert.strictEqual(second.portReleased, true)
+    assert.strictEqual(second.jobRemoved, false, 'no job on second call')
+    assert.strictEqual(second.cloneDeleted, false, 'no clone on second call')
+    assert.strictEqual(second.errors.length, 0, 'no errors on repeat')
   })
 })


### PR DESCRIPTION
## Summary

Add `/devcontainer rm <branch>` and `/devcontainer rm all` commands to fully tear down devcontainer workspaces, with pre-removal warnings for uncommitted changes and other active sessions.

## What it does

### Remove commands

- **`/devcontainer rm <branch>`** — Finds the Docker container for the workspace, stops and removes it, removes the image, releases the port, deletes the job entry, removes the override config, deletes the clone folder, and cleans up session files.
- **`/devcontainer rm all`** — Same cleanup applied to every tracked devcontainer (collected from clones directory, `ports.json`, and `jobs.json`).

### Confirmation flow

Before removing, the tool checks for:
1. **Uncommitted changes** via `getWorkspaceStatus()` (which runs `git status --porcelain`)
2. **Other active sessions** using the workspace(s) being deleted (by scanning session files in the sessions directory)

If any warnings are found, the tool returns a message stating that explicit user confirmation is required. The LLM asks the user, and if they agree, calls the tool again with `confirmed: true` to proceed.

For `rm all`, the check is optimized: scans all entries until it finds one with uncommitted changes, and checks for any other session files regardless of workspace.

## Implementation

### `plugin/core/devcontainer.js`

- **`remove()`** — Orchestrates full 10-step cleanup: find container → stop → get image ref → `docker rm` → `docker rmi` → release port → remove job → delete override → delete clone → clean sessions. Returns a detailed summary of what was done.
- **`findContainerId()`** — Finds Docker container ID for a workspace using the `devcontainer.local_folder` label.
- **`cleanupWorkspaceSessions()`** — Scans all session files in `~/.cache/opencode-devcontainers/opencode-sessions/` and deletes any whose `.workspace` matches the given path.

### `plugin/core/jobs.js`

- **`removeJob()`** — New export. Removes a job entry for a workspace, returns `true` if one existed.

### `plugin/index.js`

- **`handleRemoveSingle()`** and **`handleRemoveAll()`** — Orchestrate the rm flow: resolve workspace, run pre-removal warnings, call `remove()`, clear current session.
- **`countOtherSessions()`** — Counts session files (excluding current) by workspace path (or all if `null`).
- **`formatRemoveSummary()`** — Formats the remove result for display.
- **`confirmed` parameter** added to the devcontainer tool definition.
- Imported `remove`, `listClones`, `readPorts`, `readJobs` from core modules.

## Tests

- **Unit tests** (`test/unit/devcontainer.test.js`): 5 tests covering `remove()` with full state, missing clone folder, no port/job entries, completely unknown workspace, and idempotency.
- **Integration test** (`test/integration/devcontainer-remove.test.js`): actual Docker lifecycle — creates real containers with the devcontainer label, runs `remove()`, verifies container/image are gone and a decoy container is untouched.

All 219 tests pass.

### Running integration tests manually

Requires Docker daemon running:

```bash
node --test test/integration/devcontainer-remove.test.js
```

## Documentation

Updated `plugin/command/devcontainer.md` with rm command and the confirmation info for the LLM.

## Notes

- Only removes devcontainer clones. Worktree-based workspaces are unaffected.
- The `rm` prefix is parsed from the tool target argument, so it works naturally as `/devcontainer rm feature-x`.
- If warnings are present, the LLM must pass `confirmed: true` on the second call to proceed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for removing individual devcontainers by branch or all devcontainers at once.
  * Added confirmation prompts before destructive removal operations.
  * Removal now cleans up associated containers, images, ports, jobs, files, and sessions.
  * Added clear status summaries and error reporting for removal results.

* **Bug Fixes**
  * Improved handling of missing, ambiguous, or already-removed devcontainer resources.

* **Tests**
  * Added coverage for complete, partial, repeated, and unknown-workspace removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->