### PR TITLE
Fix Git submodule being incorrectly identified as a worktree

### DIFF
--- a/plugin/core/git.js
+++ b/plugin/core/git.js
@@ -230,9 +230,9 @@ export async function isWorktree(dir) {
       return false
     }
     
-    // Verify it contains a gitdir reference
+    // Verify it contains a gitdir reference pointing to a worktree administrative directory
     const content = await readFile(gitPath, 'utf-8')
-    return content.startsWith('gitdir:')
+    return content.startsWith('gitdir:') && /[/\\]worktrees[/\\][^/\\]+\s*$/.test(content)
   } catch {
     return false
   }

--- a/test/unit/git-worktree.test.js
+++ b/test/unit/git-worktree.test.js
@@ -63,6 +63,25 @@ describe('isWorktree', () => {
     const result = await isWorktree('/nonexistent/path')
     assert.strictEqual(result, false)
   })
+
+  test('returns false for a submodule directory', async () => {
+    const subRepo = join(testDir, 'sub-repo')
+    const submodulePath = join(mainRepo, 'sub')
+
+    mkdirSync(subRepo, { recursive: true })
+    execSync('git init -b main', { cwd: subRepo })
+    writeFileSync(join(subRepo, 'sub.txt'), 'sub')
+    execSync('git add .', { cwd: subRepo })
+    execSync('git commit -m "sub commit"', { cwd: subRepo })
+
+    // Add submodule to main repo
+    execSync('git config --global protocol.file.allow always', { cwd: mainRepo })
+    execSync(`git submodule add ${subRepo} sub`, { cwd: mainRepo })
+    execSync('git commit -m "add submodule"', { cwd: mainRepo })
+
+    const result = await isWorktree(submodulePath)
+    assert.strictEqual(result, false)
+  })
 })
 
 describe('getWorktreeMainRepo', () => {


### PR DESCRIPTION
Both Git submodules and worktrees use a `.git` file containing a `gitdir: <path>` reference. However, a worktree's `gitdir` always points to the main repository's `.git/worktrees/...` folder, whereas a submodule's `gitdir` points to `.git/modules/...`. 

Because `isWorktree` previously only checked whether the `.git` file exists and starts with `gitdir:`, submodules were incorrectly identified as worktrees. This blocked users from executing worktree commands from within submodules.

This PR refines the `isWorktree` function to inspect the `gitdir` value, ensuring it refers to a `worktrees` administrative directory (with `/worktrees/` followed by at least one directory component to prevent false positives from repository names containing 'worktrees'). It also adds corresponding unit tests to verify both cases.

Fixes #127

---
*PR created automatically by Jules for task [8200182990159883666](https://jules.google.com/task/8200182990159883666) started by @athal7*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git repository detection to distinguish worktrees from submodules and other nested repositories.
  * Prevented nested repositories from being incorrectly identified as worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->