### PR TITLE
fix(ci): remove persist-credentials false to allow semantic-release to push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The `release` job in `ci.yml` had `persist-credentials: false` on the checkout step, which prevented `semantic-release` from:
1. Pushing the version bump commit (via `@semantic-release/git`)
2. Creating the GitHub release (via `@semantic-release/github`)

## Fix

Removed `persist-credentials: false` so the `GITHUB_TOKEN` is available for git push and API operations.

## Changes

- `.github/workflows/ci.yml`: Removed `persist-credentials: false` from release job checkout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow checkout configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->