### PR TITLE
fix(ci): stop committing package.json/package-lock.json version bumps back to the repo

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -19,19 +19,16 @@ module.exports = {
     // Generate release notes
     '@semantic-release/release-notes-generator',
     
-    // Update version in package.json and publish to npm with provenance
+    // Publish to npm with provenance. package.json's committed version
+    // stays a placeholder (0.0.0-development) — semantic-release sets
+    // the real version only in this ephemeral CI checkout before
+    // `npm publish`, and never commits it back to the repo. No PR, no
+    // committed version file, ever; the npm registry and git tags are
+    // the only sources of truth for the release version.
     ['@semantic-release/npm', { provenance: true }],
-    
-    // Commit the version changes
-    [
-      '@semantic-release/git',
-      {
-        assets: ['package.json', 'package-lock.json'],
-        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
-      }
-    ],
-    
-    // Create GitHub release
+
+    // Create GitHub release directly from HEAD's tree (no version-bump
+    // commit precedes it)
     '@semantic-release/github'
   ]
 };


### PR DESCRIPTION
@semantic-release/git committed the npm-bumped package.json/package-lock.json back to main on every release (no PR, but still a committed version file). Explicit preference across every tap repo: no committed version file, ever. npm publish still gets the correct version — @semantic-release/npm sets it in this CI checkout before publishing regardless of whether anything commits it back; only the repo's own committed package.json now lags the last manually-set value instead of tracking every release.