### PR TITLE
fix(ci): enforce conventional commit format on pr titles

### DIFF
--- a/.github/workflows/conventional-title.yml
+++ b/.github/workflows/conventional-title.yml
@@ -1,0 +1,22 @@
+name: conventional pull request title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$TITLE" =~ ^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([[:alnum:]_.\/-]+\))?!?:\ .+ ]]; then
+            exit 0
+          fi
+          printf 'Pull request titles must use Conventional Commits: %s\n' "$TITLE"
+          exit 1

--- a/.github/workflows/conventional-title.yml
+++ b/.github/workflows/conventional-title.yml
@@ -1,8 +1,8 @@
 name: conventional pull request title
 
 on:
-  pull_request:
-    types: [opened, edited, reopened, ready_for_review]
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Squash-merging PR #150 landed the code-scanning-alert-1 security fix (Docker `--filter` label injection via unsanitized `workspace`), but the squash commit used PR #150's non-conventional title as its subject. `@semantic-release/commit-analyzer` only inspects commit headers against Conventional Commits patterns, so it found no releasable commit type and logged:

```
There are no relevant changes, so no new version is released.
```

The security fix landed on `main` but was never published to npm/GitHub releases.

## What

Add a PR-title lint (`.github/workflows/conventional-title.yml`), reused verbatim from `opencode-pilot`/`opencode-cmd`/`kb`, that rejects non-Conventional-Commits PR titles at open/edit time. Since squash-merge uses the PR title as the commit subject, this guarantees every future squash commit is analyzable by semantic-release.

This PR's own `fix:` type also triggers the release semantic-release owes for #150's fix.

_Generated by anthropic/claude-sonnet-5._